### PR TITLE
Add fully generic algorithms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 dist: bionic
 compiler: gcc
-sudo: false
+sudo: required # apt-get done in before_install.sh
 
 # Only build master or PRs merging into master
 branches:
@@ -16,33 +16,16 @@ matrix:
         addons:
           apt:
             packages:
-            - gfortran
             - python3-sphinx
             - valgrind
       - os: linux
         env: FLIBCPP_DEV=OFF GENERATOR=make
              FLIBCPP_FORTRAN_STD=f2003
-             CC=gcc-8 CXX=g++-8 FC=gfortran-8 
-        addons:
-          apt:
-            packages:
-            - gcc-8
-            - g++-8
-            - gfortran-8
+             GCC_VERSION=8
       - os: linux
         env: FLIBCPP_DEV=OFF GENERATOR=make
              FLIBCPP_FORTRAN_STD=f2008
-             CC=gcc-9 CXX=g++-9 FC=gfortran-9 
-        sudo: required
-        addons:
-          apt:
-            sources:
-            - ubuntu-toolchain-r-test
-            packages:
-            - gcc-9
-            - g++-9
-            - gfortran-9
-
+             GCC_VERSION=9
 # Build phases
 before_install:
   - source ./scripts/travis/before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-language: cpp
 dist: bionic
-compiler: gcc
 sudo: required # apt-get done in before_install.sh
+language: minimal
 
 # Only build master or PRs merging into master
 branches:
@@ -11,21 +10,21 @@ branches:
 # List of configurations to check
 matrix:
   include:
-      - os: linux
-        env: FLIBCPP_DEV=ON GENERATOR=ninja
-        addons:
-          apt:
-            packages:
-            - python3-sphinx
-            - valgrind
-      - os: linux
-        env: FLIBCPP_DEV=OFF GENERATOR=make
-             FLIBCPP_FORTRAN_STD=f2003
-             GCC_VERSION=8
-      - os: linux
-        env: FLIBCPP_DEV=OFF GENERATOR=make
-             FLIBCPP_FORTRAN_STD=f2008
-             GCC_VERSION=9
+    - os: linux
+      env: FLIBCPP_DEV=ON GENERATOR=ninja
+      addons:
+        apt:
+          packages:
+          - python3-sphinx
+          - valgrind
+    - os: linux
+      env: FLIBCPP_DEV=OFF GENERATOR=make
+           FLIBCPP_FORTRAN_STD=f2003
+           GCC_VERSION=8
+    - os: linux
+      env: FLIBCPP_DEV=OFF GENERATOR=make
+           FLIBCPP_FORTRAN_STD=f2008
+           GCC_VERSION=9
 # Build phases
 before_install:
   - source ./scripts/travis/before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
   include:
       - os: linux
         env: FLIBCPP_DEV=ON GENERATOR=ninja
-             FLIBCPP_FORTRAN_STD=f2003
         addons:
           apt:
             packages:
@@ -22,18 +21,20 @@ matrix:
             - valgrind
       - os: linux
         env: FLIBCPP_DEV=OFF GENERATOR=make
-             FLIBCPP_FORTRAN_STD=f2008
+             FLIBCPP_FORTRAN_STD=f2003
         addons:
           apt:
             packages:
-            - gfortran
+            - gcc-8
+            - gfortran-8
       - os: linux
         env: FLIBCPP_DEV=OFF GENERATOR=make
              FLIBCPP_FORTRAN_STD=f2008
         addons:
           apt:
             packages:
-            - gfortran
+            - gcc-9
+            - gfortran-9
 
 # Build phases
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,25 @@ matrix:
       - os: linux
         env: FLIBCPP_DEV=OFF GENERATOR=make
              FLIBCPP_FORTRAN_STD=f2003
+             CC=gcc-8 CXX=g++-8 FC=gfortran-8 
         addons:
           apt:
             packages:
             - gcc-8
+            - g++-8
             - gfortran-8
       - os: linux
         env: FLIBCPP_DEV=OFF GENERATOR=make
              FLIBCPP_FORTRAN_STD=f2008
+             CC=gcc-9 CXX=g++-9 FC=gfortran-9 
+        sudo: required
         addons:
           apt:
+            sources:
+            - ubuntu-toolchain-r-test
             packages:
             - gcc-9
+            - g++-9
             - gfortran-9
 
 # Build phases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ function(swig_fortran_add_module name)
       cxx_std_11
   )
 
-  if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  if (FLIBCPP_FORTRAN_STD AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     # Compile Fortran code with given standard
     target_compile_options(${name}
       PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:-std=${FLIBCPP_FORTRAN_STD}>

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -9,16 +9,11 @@ Examples
 The following standalone codes demonstrate how Flibcpp can be used in native
 Fortran code.
 
-String conversion and sort
+Random numbers and sorting
 ==========================
 
-This example:
-
- - Introspects the Flibcpp version;
- - Converts a user input to an integer, validating it with useful error
-   messages;
- - Fills an array with normally-distributed real numbers; and
- - Sorts the array before printing the first few entries.
+This simple example generates an array of normally-distributed double-precision
+reals, sorts them, and then shuffles them again.
 
 .. literalinclude:: ../example/sort.f90
    :linenos:
@@ -30,6 +25,39 @@ Strings and vectors of strings can be easily manipulated and converted to and
 from native Fortran strings.
 
 .. literalinclude:: ../example/vecstr.f90
+   :linenos:
+
+.. _example_generic:
+
+Generic sorting
+===============
+
+Since sorting algorithms often allow :math:`O(N)` algorithms to be written in
+:math:`O(\log N)`, providing generic sorting routines is immensely useful in
+applications that operate on large chunks of data. This example demonstrates
+the generic version of the :ref:`modules_algorithm_argsort` subroutine by
+sorting a native Fortran array of native Fortran types using a native Fortran
+subroutine. The only C interaction needed is to create C pointers to the
+Fortran array entries and to provide a C-bound comparator that converts those
+pointers back to native Fortran pointers.
+
+.. literalinclude:: ../example/sort_generic.f90
+   :linenos:
+
+.. _example_utils:
+
+Example utilities module
+========================
+
+This pure-Fortran module builds on top of functionality from Flibcpp. It
+provides procedures to:
+
+ - Format and print the Flibcpp version;
+ - Converts a user input to an integer, validating it with useful error
+   messages;
+ - Reads a dynamically sized vector of strings from the user.
+
+.. literalinclude:: ../example/example_utils.f90
    :linenos:
 
 .. ############################################################################

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -38,8 +38,8 @@ applications that operate on large chunks of data. This example demonstrates
 the generic version of the :ref:`modules_algorithm_argsort` subroutine by
 sorting a native Fortran array of native Fortran types using a native Fortran
 subroutine. The only C interaction needed is to create C pointers to the
-Fortran array entries and to provide a C-bound comparator that converts those
-pointers back to native Fortran pointers.
+Fortran array entries and to provide a C-bound comparator that
+converts those pointers back to native Fortran pointers. [#c_f_pointer]_
 
 .. literalinclude:: ../example/sort_generic.f90
    :linenos:
@@ -59,6 +59,27 @@ provides procedures to:
 
 .. literalinclude:: ../example/example_utils.f90
    :linenos:
+
+
+.. rubric:: Footnotes
+
+.. [#c_f_pointer] Older versions of Gfortran (before GCC-8) fail to compile the
+   generic sort example because of a bug that incorrectly claims that taking
+   the C pointer of a scalar Fortran value is a violation of the standard:
+
+   .. code-block:: none
+
+      ../example/sort_generic.f90:84:38:
+
+           call c_f_pointer(cptr=rcptr, fptr=rptr)
+                                            1
+      Error: TS 29113/TS 18508: Noninteroperable array FPTR at (1) to
+      C_F_POINTER: Expression is a noninteroperable derived type
+
+   See `this bug report`_ for more details.
+
+   .. _this bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84924
+
 
 .. ############################################################################
 .. end of doc/examples.rst

--- a/doc/modules/algorithm.rst
+++ b/doc/modules/algorithm.rst
@@ -10,19 +10,18 @@ Algorithm
 
 The ``flc_algorithm`` module wraps C++ standard `<algorithm>`_ routines.
 Instead of taking pairs of iterators, the Flibcpp algorithm subroutines accept
-target-qualified 1-D arrays.
-
-Algorithms that take comparators (e.g. sorting and searching) are instantiated
-with function pointers that allow user functions to add arbitrary ordering by
-defining ``bind(C)`` functions.
-
-Wherever possible, array indices are returned as Fortran 1-offset native
-integers, with the value 0 indicating off-the-end (e.g. "not found").
+target-qualified one-dimensional arrays. All algorithms follow the
+:ref:`indexing convention <conventions_indexing>` that the first element of an
+array has index 1, and an index of 0 indicates "not found".
 
 .. _<algorithm> : https://en.cppreference.com/w/cpp/numeric/random
 
 Sorting
 =======
+
+Sorting algorithms for numeric types default to increasing order when provided
+with a single array argument. Numeric sorting routines accept an optional
+second argument, a comparator function,
 
 sort
 ----
@@ -56,11 +55,10 @@ takes an array to analyze and an empty array of integers to fill::
   use flc_algorithm, only : argsort, INDEX_INT
   implicit none
   integer, dimension(5) :: iarr = [ 2, 5, -2, 3, -10000]
-  integer(INDEX_INT), dimension(5) :: idx
+  integer(INDEX_INT), dimension(size(iarr)) :: idx
 
   call argsort(iarr, idx)
-  ! This line prints a sorted array:
-  write(*,*) iarr(idx)
+  write(*,*) iarr(idx) ! Prints the sorted array
 
 Note that the index array is always a ``INDEX_INT``, which is an alias to
 ``C_INT``. On some compilers and platforms, this may be the same as native

--- a/doc/modules/algorithm.rst
+++ b/doc/modules/algorithm.rst
@@ -21,7 +21,17 @@ Sorting
 
 Sorting algorithms for numeric types default to increasing order when provided
 with a single array argument. Numeric sorting routines accept an optional
-second argument, a comparator function,
+second argument, a comparator function, which should return ``true`` if the
+first argument is strictly less than the right-hand side.
+
+.. warning:: For every value of ``a`` and ``b``, the comparator ``cmp`` *must*
+   satisfy ``.not. (cmp(a, b) .and. cmp(b, a))``. If this strict ordering is
+   not satisfied, some of the algorithms below may crash the program.
+
+All sorting algorithms are *also* instantiated so that they accept an array of
+``type(C_PTR)`` and a generic comparator function. **This enables arrays of any
+native Fortran object to be sorted**. See :ref:`the generic
+sorting example <example_generic>` for a demonstration.
 
 sort
 ----
@@ -44,6 +54,8 @@ Checking the ordering of array is just as simple::
   logical :: sortitude
 
   sortitude = is_sorted(iarr)
+
+.. _modules_algorithm_argsort:
 
 argsort
 -------
@@ -74,6 +86,10 @@ zero.
 
 Searching
 =========
+
+Like the sorting algorithms, searching algorithms are instantiated on numeric
+types and the C pointer type, and they provide an optional procedure pointer
+argument that allows the arrays to be ordered with an arbitrary comparator.
 
 .. _modules_algorithm_binary_search:
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -30,6 +30,9 @@ swig_fortran_add_example(sort
 swig_fortran_add_example(vecstr
   flc_string flc_vector example_utils_lib)
 
+swig_fortran_add_example(sort_generic
+  flc_algorithm example_utils_lib)
+
 #---------------------------------------------------------------------------##
 # TESTS
 #---------------------------------------------------------------------------##

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,11 +11,28 @@ macro(swig_fortran_add_example name)
   target_link_libraries(${name}.exe ${ARGN})
 endmacro()
 
+#---------------------------------------------------------------------------##
+# TEST LIBRARIES
+#---------------------------------------------------------------------------##
+
+add_library(example_utils_lib
+  "example_utils.f90"
+)
+target_link_libraries(example_utils_lib flc flc_string flc_vector)
+
+#---------------------------------------------------------------------------##
+# EXAMPLES
+#---------------------------------------------------------------------------##
+
 swig_fortran_add_example(sort
-  flc_algorithm flc_random flc_string)
+  flc_algorithm flc_random flc_string example_utils_lib)
 
 swig_fortran_add_example(vecstr
-  flc_string flc_vector)
+  flc_string flc_vector example_utils_lib)
+
+#---------------------------------------------------------------------------##
+# TESTS
+#---------------------------------------------------------------------------##
 
 if (BUILD_TESTING)
   add_test(

--- a/example/example_utils.f90
+++ b/example/example_utils.f90
@@ -1,0 +1,115 @@
+!-----------------------------------------------------------------------------!
+! \file   example/example_utils.f90
+! \brief  example_utils module
+! \note   Copyright (c) 2019 Oak Ridge National Laboratory, UT-Battelle, LLC.
+!-----------------------------------------------------------------------------!
+
+module example_utils
+  use, intrinsic :: ISO_FORTRAN_ENV
+  use, intrinsic :: ISO_C_BINDING
+  implicit none
+  integer, parameter :: STDOUT = OUTPUT_UNIT, STDIN = INPUT_UNIT
+  public
+    
+contains
+
+subroutine write_version()
+  use flc
+  implicit none
+  ! Print version information
+  write(STDOUT, "(a)") "========================================"
+  write(STDOUT, "(a, a)") "Flibcpp version: ", get_flibcpp_version()
+  write(STDOUT, "(a, 2(i1,'.'), (i1), a)") "(Numeric version: ", &
+      flibcpp_version_major, flibcpp_version_minor, flibcpp_version_patch, &
+      ")"
+  write(STDOUT, "(a)") "========================================"
+end subroutine
+    
+! Loop until the user inputs a positive integer. Catch error conditions. 
+function read_positive_int(desc) result(result_int)
+  use flc
+  use flc_string, only : stoi
+  implicit none
+  character(len=*), intent(in) :: desc
+  character(len=80) :: readstr
+  integer :: result_int, io_ierr
+  do
+    write(STDOUT, *) "Enter " // desc // ": "
+    read(STDIN, "(a)", iostat=io_ierr) readstr
+    if (io_ierr == IOSTAT_END) then
+      ! Error condition: ctrl-D during input
+      write(STDOUT, *) "User terminated"
+      stop 1
+    endif
+
+    result_int = stoi(readstr)
+    if (ierr == 0) then
+      if (result_int <= 0) then
+        ! Error condition: non-positive value
+        write(STDOUT, *) "Invalid " // desc // ": ", result_int
+        continue
+      end if
+
+      write(STDOUT, *) "Read " // desc // "=", result_int
+      exit
+    endif
+
+    if (ierr == SWIG_OVERFLOWERROR) then
+      ! Error condition: integer doesn't fit in native integer
+      write(STDOUT,*) "Your integer is too darn big!"
+    else if (ierr == SWIG_VALUEERROR) then
+      ! Error condition: not an integer at all
+      write(STDOUT,*) "That text you entered? It wasn't an integer."
+    else
+      write(STDOUT,*) "Unknown error", ierr
+    end if
+    write(STDOUT,*) "(Detailed error message: ", get_serr(), ")"
+
+    ! Clear error flag so the next call to stoi succeeds
+    ierr = 0
+  end do
+end function
+
+! Loop until the user inputs a positive integer. Catch error conditions. 
+subroutine read_strings(vec)
+  use flc
+  use flc_string, only : String
+  use flc_vector, only : VectorString
+  use ISO_FORTRAN_ENV
+  implicit none
+  type(VectorString), intent(out) :: vec
+  integer, parameter :: STDOUT = OUTPUT_UNIT, STDIN = INPUT_UNIT
+  character(len=80) :: readstr
+  integer :: io_ierr
+  type(String) :: str
+
+  ! Allocate the vector
+  vec = VectorString()
+
+  do
+    ! Request and read a string
+    write(STDOUT, "(a, i3, a)") "Enter string #", vec%size() + 1, &
+        " or Ctrl-D/empty string to complete"
+    read(STDIN, "(a)", iostat=io_ierr) readstr
+    if (io_ierr == IOSTAT_END) then
+      ! Break out of loop on ^D (EOF)
+      exit
+    end if
+
+    ! Add string to the end of the vector
+    call vec%push_back(trim(readstr))
+    ! Get a String object reference to the back to check if it's empty
+    str = vec%back_ref()
+    if (str%empty()) then
+      ! Remove the empty string
+      call vec%pop_back()
+      exit
+    end if
+  end do
+end subroutine
+
+end module
+
+!-----------------------------------------------------------------------------!
+! end of example/example_utils.f90
+!-----------------------------------------------------------------------------!

--- a/example/run-examples.sh
+++ b/example/run-examples.sh
@@ -35,6 +35,14 @@ three
 20
 EOF
 
+run_test sort_generic << EOF
+5
+a short string
+a shirt string
+shorter
+and the next string is unallocated
+EOF
+
 run_test vecstr << EOF
 This is the first string
 a second string

--- a/example/sort.f90
+++ b/example/sort.f90
@@ -7,7 +7,7 @@
 program sort_example
   use, intrinsic :: ISO_C_BINDING
   use flc
-  use flc_algorithm, only : sort
+  use flc_algorithm, only : sort, shuffle
   use flc_random, only : Engine, normal_distribution
   use example_utils, only : write_version, read_positive_int, STDOUT
   implicit none
@@ -29,9 +29,11 @@ program sort_example
 
   ! Sort the array
   call sort(x)
-
-  ! Write output
   write(STDOUT, "(a, 4(f8.3,','))") "First few elements:", x(:min(4, size(x)))
+
+  ! Rearrange it randomly
+  call shuffle(rng, x)
+  write(STDOUT, "(a, 4(f8.3,','))") "After shuffling:", x(:min(4, size(x)))
 
   call rng%release()
 end program

--- a/example/sort_generic.f90
+++ b/example/sort_generic.f90
@@ -1,0 +1,153 @@
+!-----------------------------------------------------------------------------!
+! \file   example/sort_generic.f90
+!
+! Copyright (c) 2019 Oak Ridge National Laboratory, UT-Battelle, LLC.
+!-----------------------------------------------------------------------------!
+
+! Mock-up of a user-created type and comparison operator
+module sort_generic_extras
+  implicit none
+  public
+
+  ! Declare an example Fortran derived type
+  type :: FortranString
+    character(len=:), allocatable :: chars
+  end type
+
+  ! Declare a 'less than' operator for that type
+  interface operator(<)
+    module procedure fortranstring_less
+  end interface
+
+contains
+
+elemental function fortranstring_less(self, other) &
+    result(fresult)
+  type(FortranString), intent(in) :: self
+  type(FortranString), intent(in) :: other
+  logical :: fresult
+  integer :: i, lchar, rchar
+
+  if (.not. allocated(self%chars) .and. .not. allocated(other%chars)) then
+    ! Both deallocated, therefore equal
+    fresult = .false.
+    return
+  elseif (.not. allocated(self%chars)) then
+    ! self deallocated, therefore less
+    fresult = .true.
+    return
+  elseif (.not. allocated(other%chars)) then
+    ! other deallocated, therefore greater
+    fresult = .false.
+    return
+  endif
+
+  ! If LHS is shorter, it is "less than" the RHS.
+  if (len(self%chars) < len(other%chars)) then
+    fresult = .true.
+    return
+  elseif (len(self%chars) > len(other%chars)) then
+    fresult = .false.
+    return
+  endif
+
+  ! If any character code is less than the RHS, it is less than.
+  do i = 1, len(self%chars)
+    lchar = ichar(self%chars(i:i))
+    rchar = ichar(other%chars(i:i))
+    if (lchar < rchar) then
+      fresult = .true.
+      return
+    elseif (lchar > rchar) then
+      fresult = .false.
+      return
+    endif
+  end do
+
+  ! Everything is equal: therefore not strictly "less than"
+  fresult = .false.
+end function
+
+! C++-accessible comparison function for two pointers-to-strings
+function compare_strings(lcptr, rcptr) bind(C) &
+    result(fresult)
+  use, intrinsic :: ISO_C_BINDING
+  type(C_PTR), intent(in), value :: lcptr
+  type(C_PTR), intent(in), value :: rcptr
+  logical(C_BOOL) :: fresult
+  type(FortranString), pointer :: lptr
+  type(FortranString), pointer :: rptr
+
+  if (c_associated(lcptr) .and. c_associated(rcptr)) then
+    ! Both associated: convert from C to Fortran pointers
+    call c_f_pointer(cptr=lcptr, fptr=lptr)
+    call c_f_pointer(cptr=rcptr, fptr=rptr)
+
+    ! Compare the strings
+    fresult = (lptr < rptr)
+  elseif (.not. c_associated(lcptr)) then
+    ! LHS is null => "less than"
+    fresult = .true.
+  elseif (.not. c_associated(rcptr)) then
+    fresult = .false.
+  endif
+
+end function
+end module
+
+program sort_generic_example
+  use, intrinsic :: ISO_FORTRAN_ENV
+  use, intrinsic :: ISO_C_BINDING
+  use flc
+  use flc_algorithm, only : argsort, INDEX_INT
+  use sort_generic_extras, only : compare_strings, FortranString
+  use example_utils, only : write_version, read_positive_int, STDOUT, STDIN
+  implicit none
+  type(FortranString), dimension(:), allocatable, target :: fs_array
+  type(C_PTR), dimension(:), allocatable, target :: ptrs
+  integer(INDEX_INT), dimension(:), allocatable, target :: ordering
+  character(len=80) :: readstr
+  integer :: arr_size, i, io_ierr
+
+  call write_version()
+
+  ! Read strings
+  arr_size = read_positive_int("string array size")
+  allocate(fs_array(arr_size))
+  do i = 1, arr_size
+    write(STDOUT, "(a, i3)") "Enter string #", i
+    read(STDIN, "(a)", iostat=io_ierr) readstr
+    if (io_ierr == IOSTAT_END) then
+      ! Leave further strings unallocated
+      exit
+    endif
+    ! Allocate string
+    allocate(fs_array(i)%chars, source=trim(readstr))
+  enddo
+
+  ! Create C pointers to the Fortran objects
+  ptrs = [(c_loc(fs_array(i)), i = 1, arr_size)]
+
+  ! Use 'argsort' to determine the new ordering
+  allocate(ordering(arr_size))
+  call argsort(ptrs, ordering, compare_strings)
+  write(STDOUT, "(a, 20(i3))") "New order:", ordering
+
+  ! Reorder the Fortran data
+  fs_array = fs_array(ordering)
+
+  ! Print the results
+  write(STDOUT, *) "Sorted:"
+  do i = 1, arr_size
+    if (allocated(fs_array(i)%chars)) then
+      write(STDOUT, "(i3, ': ', a)") i, fs_array(i)%chars
+    else
+      write(STDOUT, "(i3, ': ', a)") i, "<UNALLOCATED>"
+    endif
+  enddo
+
+end program
+
+!-----------------------------------------------------------------------------!
+! end of example/sort.f90
+!-----------------------------------------------------------------------------!

--- a/example/vecstr.f90
+++ b/example/vecstr.f90
@@ -5,13 +5,12 @@
 !-----------------------------------------------------------------------------!
 
 program vecstr_example
-  use, intrinsic :: ISO_FORTRAN_ENV
   use, intrinsic :: ISO_C_BINDING
   use flc
   use flc_string, only : String
   use flc_vector, only : VectorString
+  use example_utils, only : read_strings, STDOUT
   implicit none
-  integer, parameter :: STDOUT = OUTPUT_UNIT
   integer :: i
   type(VectorString) :: vec
   type(String) :: back, front
@@ -68,44 +67,6 @@ program vecstr_example
 
   ! Free allocated vector memory
   call vec%release()
-contains
-
-! Loop until the user inputs a positive integer. Catch error conditions. 
-subroutine read_strings(vec)
-  use flc
-  use flc_string, only : stoi
-  use ISO_FORTRAN_ENV
-  implicit none
-  type(VectorString), intent(out) :: vec
-  integer, parameter :: STDOUT = OUTPUT_UNIT, STDIN = INPUT_UNIT
-  character(len=80) :: readstr
-  integer :: io_ierr
-  type(String) :: str
-
-  ! Allocate the vector
-  vec = VectorString()
-
-  do
-    ! Request and read a string
-    write(STDOUT, "(a, i3, a)") "Enter string #", vec%size() + 1, &
-        " or Ctrl-D/empty string to complete"
-    read(STDIN, "(a)", iostat=io_ierr) readstr
-    if (io_ierr == IOSTAT_END) then
-      ! Break out of loop on ^D (EOF)
-      exit
-    end if
-
-    ! Add string to the end of the vector
-    call vec%push_back(trim(readstr))
-    ! Get a String object reference to the back to check if it's empty
-    str = vec%back_ref()
-    if (str%empty()) then
-      ! Remove the empty string
-      call vec%pop_back()
-      exit
-    end if
-  end do
-end subroutine
 end program
 
 !-----------------------------------------------------------------------------!

--- a/example/vecstr.f90
+++ b/example/vecstr.f90
@@ -9,12 +9,15 @@ program vecstr_example
   use flc
   use flc_string, only : String
   use flc_vector, only : VectorString
-  use example_utils, only : read_strings, STDOUT
+  use example_utils, only : read_strings, write_version, STDOUT
   implicit none
   integer :: i
   type(VectorString) :: vec
   type(String) :: back, front
   character(C_CHAR), dimension(:), pointer :: chars
+
+  ! Print version information
+  call write_version()
 
   ! Read a vector of strings
   call read_strings(vec)

--- a/include/flc.i
+++ b/include/flc.i
@@ -78,11 +78,11 @@ using std::size_t;
        (double   *DATA, size_t DATASIZE),
        (void    **DATA, size_t DATASIZE)};
 
-%apply (const SWIGTYPE *DATA, size_t SIZE) {
-       (const int32_t  *DATA, size_t DATASIZE),
-       (const int64_t  *DATA, size_t DATASIZE),
-       (const double   *DATA, size_t DATASIZE),
-       (void * const   *DATA, size_t DATASIZE)};
+%apply (SWIGTYPE const *DATA, size_t SIZE) {
+       (int32_t  const *DATA, size_t DATASIZE),
+       (int64_t  const *DATA, size_t DATASIZE),
+       (double   const *DATA, size_t DATASIZE),
+       (void*    const *DATA, size_t DATASIZE)};
 
 /* -------------------------------------------------------------------------
  * Version information

--- a/include/flc.i
+++ b/include/flc.i
@@ -82,7 +82,7 @@ using std::size_t;
        (const int32_t  *DATA, size_t DATASIZE),
        (const int64_t  *DATA, size_t DATASIZE),
        (const double   *DATA, size_t DATASIZE),
-       (const void    **DATA, size_t DATASIZE)};
+       (void * const   *DATA, size_t DATASIZE)};
 
 /* -------------------------------------------------------------------------
  * Version information

--- a/include/flc.i
+++ b/include/flc.i
@@ -75,12 +75,14 @@ using std::size_t;
 %apply (SWIGTYPE *DATA, size_t SIZE) {
        (int32_t  *DATA, size_t DATASIZE),
        (int64_t  *DATA, size_t DATASIZE),
-       (double   *DATA, size_t DATASIZE) };
+       (double   *DATA, size_t DATASIZE),
+       (void    **DATA, size_t DATASIZE)};
 
 %apply (const SWIGTYPE *DATA, size_t SIZE) {
        (const int32_t  *DATA, size_t DATASIZE),
        (const int64_t  *DATA, size_t DATASIZE),
-       (const double   *DATA, size_t DATASIZE) };
+       (const double   *DATA, size_t DATASIZE),
+       (const void    **DATA, size_t DATASIZE)};
 
 /* -------------------------------------------------------------------------
  * Version information

--- a/include/flc_algorithm.i
+++ b/include/flc_algorithm.i
@@ -42,12 +42,12 @@ static RETURN_TYPE FUNCNAME##_cmp(ARGS, bool (*cmp)(T, T)) {
 // >>> Create a native function pointer interface for the given comparator.
 %define %flc_cmp_funptr(CTYPE, FTYPE)
 
-#define SWIG_cmp_funptr SWIG_cmp_funptr_## %mangle(CTYPE)
+#define flc_cmp_funptr flc_cmp_funptr_ ## %mangle(CTYPE)
 
 // Define an abstract interface that gets inserted into the module
-%fragment("SWIG_cmp_funptr_"{CTYPE}, "fdecl", noblock=1)
+%fragment("flc_cmp_funptr"{CTYPE}, "fdecl", noblock=1)
 { abstract interface
-   function SWIG_cmp_funptr(left, right) bind(C) &
+   function flc_cmp_funptr(left, right) bind(C) &
        result(fresult)
      use, intrinsic :: ISO_C_BINDING
      FTYPE, intent(in), value :: left, right
@@ -56,8 +56,9 @@ static RETURN_TYPE FUNCNAME##_cmp(ARGS, bool (*cmp)(T, T)) {
  end interface}
 
 %apply bool (*)(SWIGTYPE, SWIGTYPE) { bool (*)(CTYPE, CTYPE) };
-%typemap(ftype, in={procedure(SWIG_cmp_funptr)}, fragment="SWIG_cmp_funptr_"{CTYPE}, noblock=1) bool (*)(CTYPE, CTYPE)
-  {procedure(SWIG_cmp_funptr), pointer}
+%typemap(ftype, in={procedure(flc_cmp_funptr)},
+         fragment="flc_cmp_funptr"{CTYPE}, noblock=1) bool (*)(CTYPE, CTYPE)
+  {procedure(flc_cmp_funptr), pointer}
 
 #undef SWIG_cmp_funptr
 

--- a/include/flc_algorithm.i
+++ b/include/flc_algorithm.i
@@ -30,18 +30,24 @@ static RETURN_TYPE FUNCNAME##_cmp(ARGS, bool (*cmp)(T, T)) {
 }
 }
 
+// Instantiate numeric overloads
 %flc_template_numeric(FUNCNAME, FUNCNAME)
 %flc_template_numeric(FUNCNAME##_cmp, FUNCNAME)
+
+// Instantiate comparators with void* arguments
+%template(FUNCNAME) FUNCNAME##_cmp<void*>;
 
 %enddef
 
 // >>> Create a native function pointer interface for the given comparator.
 %define %flc_cmp_funptr(CTYPE, FTYPE)
 
+#define SWIG_cmp_funptr SWIG_cmp_funptr_## %mangle(CTYPE)
+
 // Define an abstract interface that gets inserted into the module
 %fragment("SWIG_cmp_funptr_"{CTYPE}, "fdecl", noblock=1)
 { abstract interface
-   function SWIG_cmp_funptr_##CTYPE(left, right) bind(C) &
+   function SWIG_cmp_funptr(left, right) bind(C) &
        result(fresult)
      use, intrinsic :: ISO_C_BINDING
      FTYPE, intent(in), value :: left, right
@@ -50,8 +56,10 @@ static RETURN_TYPE FUNCNAME##_cmp(ARGS, bool (*cmp)(T, T)) {
  end interface}
 
 %apply bool (*)(SWIGTYPE, SWIGTYPE) { bool (*)(CTYPE, CTYPE) };
-%typemap(ftype, in={procedure(SWIG_cmp_funptr_##CTYPE)}, fragment="SWIG_cmp_funptr_"{CTYPE}, noblock=1) bool (*)(CTYPE, CTYPE)
-  {procedure(SWIG_cmp_funptr_##CTYPE), pointer}
+%typemap(ftype, in={procedure(SWIG_cmp_funptr)}, fragment="SWIG_cmp_funptr_"{CTYPE}, noblock=1) bool (*)(CTYPE, CTYPE)
+  {procedure(SWIG_cmp_funptr), pointer}
+
+#undef SWIG_cmp_funptr
 
 %enddef
 
@@ -79,9 +87,11 @@ typedef int index_int;
        (const int32_t  *DATA1, size_t DATASIZE1),
        (const int64_t  *DATA1, size_t DATASIZE1),
        (const double   *DATA1, size_t DATASIZE1),
+       (const void    **DATA1, size_t DATASIZE1),
        (const int32_t  *DATA2, size_t DATASIZE2),
        (const int64_t  *DATA2, size_t DATASIZE2),
-       (const double   *DATA2, size_t DATASIZE2) };
+       (const double   *DATA2, size_t DATASIZE2),
+       (const void    **DATA2, size_t DATASIZE2)};
 
 
 // Make function pointers available as generic types
@@ -96,6 +106,7 @@ typedef int index_int;
 %flc_cmp_funptr(int64_t,   integer(C_INT64_T))
 %flc_cmp_funptr(double,    real(C_DOUBLE))
 %flc_cmp_funptr(index_int, integer(INDEX_INT))
+%flc_cmp_funptr(void*,     type(C_PTR))
 
 /* -------------------------------------------------------------------------
  * Sorting routines
@@ -232,4 +243,4 @@ static void shuffle(std::SWIG_MERSENNE_TWISTER& g, T *DATA, size_t DATASIZE) {
 }
 
 %flc_template_numeric(shuffle, shuffle)
-
+%template(shuffle) shuffle<void*>;

--- a/include/flc_algorithm.i
+++ b/include/flc_algorithm.i
@@ -40,6 +40,7 @@ static RETURN_TYPE FUNCNAME##_cmp(ARGS, bool (*cmp)(T, T)) {
 %enddef
 
 // >>> Create a native function pointer interface for the given comparator.
+
 %define %flc_cmp_funptr(CTYPE, FTYPE)
 
 #define flc_cmp_funptr flc_cmp_funptr_ ## %mangle(CTYPE)

--- a/include/flc_algorithm.i
+++ b/include/flc_algorithm.i
@@ -86,14 +86,14 @@ typedef int index_int;
 %apply (SWIGTYPE *DATA, size_t SIZE) { (index_int *IDX, size_t IDXSIZE) };
 
 %apply (const SWIGTYPE *DATA, size_t SIZE) {
-       (const int32_t  *DATA1, size_t DATASIZE1),
-       (const int64_t  *DATA1, size_t DATASIZE1),
-       (const double   *DATA1, size_t DATASIZE1),
-       (const void    **DATA1, size_t DATASIZE1),
-       (const int32_t  *DATA2, size_t DATASIZE2),
-       (const int64_t  *DATA2, size_t DATASIZE2),
-       (const double   *DATA2, size_t DATASIZE2),
-       (const void    **DATA2, size_t DATASIZE2)};
+       (int32_t  const *DATA1, size_t DATASIZE1),
+       (int64_t  const *DATA1, size_t DATASIZE1),
+       (double   const *DATA1, size_t DATASIZE1),
+       (void*    const *DATA1, size_t DATASIZE1),
+       (int32_t  const *DATA2, size_t DATASIZE2),
+       (int64_t  const *DATA2, size_t DATASIZE2),
+       (double   const *DATA2, size_t DATASIZE2),
+       (void*    const *DATA2, size_t DATASIZE2)};
 
 
 // Make function pointers available as generic types

--- a/scripts/travis/before_install.sh
+++ b/scripts/travis/before_install.sh
@@ -20,14 +20,13 @@ fi
 if [ -n "${GCC_VERSION}" ]; then
   # Suffix for compilers and packages
   _GCCV="-${GCC_VERSION}"
-fi
 
-sudo apt-get install gfortran${_GCCV} -y
-
-if [ -n "${GCC_VERSION}" ]; then
+  # Download GCC packages
   sudo apt-get install gcc${_GCCV} -y
   sudo apt-get install g++${_GCCV} -y
 fi
+
+sudo apt-get install gfortran${_GCCV} -y
 
 set +x
 

--- a/scripts/travis/before_install.sh
+++ b/scripts/travis/before_install.sh
@@ -3,12 +3,46 @@
 # File  : example/before_install.sh
 ###############################################################################
 
+###############################################################################
+# APT PACKAGE INSTALLS
+#
+# see https://docs.travis-ci.com/user/installing-dependencies
+###############################################################################
+
+set -x
+
+if [ "${GCC_VERSION}" = "9" ]; then
+  # Special repo needed for new GCC version
+  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  sudo apt-get update -q
+fi
+
+if [ -n "${GCC_VERSION}" ]; then
+  # Suffix for compilers and packages
+  _GCCV="-${GCC_VERSION}"
+fi
+
+sudo apt-get install gfortran${_GCCV} -y
+
+if [ -n "${GCC_VERSION}" ]; then
+  sudo apt-get install gcc${_GCCV} -y
+  sudo apt-get install g++${_GCCV} -y
+fi
+
+set +x
+
+###############################################################################
+# ENVIRONMENT VARIABLES
+###############################################################################
+
 export SOURCE_ROOT=${PWD}
 export BUILD_ROOT=${SOURCE_ROOT}/build
 export INSTALL_ROOT=${HOME}/install
 export CMAKE_PREFIX_PATH=${INSTALL_ROOT}:${CMAKE_PREFIX_PATH}
 export PATH=${INSTALL_ROOT}/bin:${PATH}
-export FC=${FC:-gfortran}
+export FC=${FC:-gfortran${_GCCV}}
+export CC=${CC:-gcc${_GCCV}}
+export CXX=${CXX:-g++${_GCCV}}
 
 mkdir -p ${BUILD_ROOT}
 

--- a/src/flc_algorithm.f90
+++ b/src/flc_algorithm.f90
@@ -23,7 +23,7 @@ integer, parameter, public :: INDEX_INT = C_INT
   integer(C_SIZE_T), public :: size = 0
  end type
  abstract interface
-   function SWIG_cmp_funptr_int32_t(left, right) bind(C) &
+   function flc_cmp_funptr_int32_t(left, right) bind(C) &
        result(fresult)
      use, intrinsic :: ISO_C_BINDING
      integer(C_INT32_T), intent(in), value :: left, right
@@ -31,7 +31,7 @@ integer, parameter, public :: INDEX_INT = C_INT
    end function
  end interface
  abstract interface
-   function SWIG_cmp_funptr_int64_t(left, right) bind(C) &
+   function flc_cmp_funptr_int64_t(left, right) bind(C) &
        result(fresult)
      use, intrinsic :: ISO_C_BINDING
      integer(C_INT64_T), intent(in), value :: left, right
@@ -39,7 +39,7 @@ integer, parameter, public :: INDEX_INT = C_INT
    end function
  end interface
  abstract interface
-   function SWIG_cmp_funptr_double(left, right) bind(C) &
+   function flc_cmp_funptr_double(left, right) bind(C) &
        result(fresult)
      use, intrinsic :: ISO_C_BINDING
      real(C_DOUBLE), intent(in), value :: left, right
@@ -47,7 +47,7 @@ integer, parameter, public :: INDEX_INT = C_INT
    end function
  end interface
  abstract interface
-   function SWIG_cmp_funptr_void_Sm_(left, right) bind(C) &
+   function flc_cmp_funptr_void_Sm_(left, right) bind(C) &
        result(fresult)
      use, intrinsic :: ISO_C_BINDING
      type(C_PTR), intent(in), value :: left, right
@@ -699,7 +699,7 @@ end subroutine
 subroutine swigf_sort__SWIG_4(data, cmp)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT32_T), dimension(:), target :: data
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
 
@@ -711,7 +711,7 @@ end subroutine
 subroutine swigf_sort__SWIG_5(data, cmp)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT64_T), dimension(:), target :: data
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
 
@@ -723,7 +723,7 @@ end subroutine
 subroutine swigf_sort__SWIG_6(data, cmp)
 use, intrinsic :: ISO_C_BINDING
 real(C_DOUBLE), dimension(:), target :: data
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
 
@@ -750,7 +750,7 @@ end subroutine
 subroutine swigf_sort__SWIG_7(data, cmp)
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), dimension(:), target :: data
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
 
@@ -816,7 +816,7 @@ result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 integer(C_INT32_T), dimension(:), intent(in), target :: data
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
@@ -832,7 +832,7 @@ result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 integer(C_INT64_T), dimension(:), intent(in), target :: data
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
@@ -848,7 +848,7 @@ result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 real(C_DOUBLE), dimension(:), intent(in), target :: data
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
@@ -865,7 +865,7 @@ use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 class(SWIGTYPE_p_p_void), intent(in) :: data
 integer(C_SIZE_T), intent(in) :: datasize
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 integer(C_INT) :: fresult 
 type(SwigClassWrapper) :: farg1 
 integer(C_SIZE_T) :: farg2 
@@ -933,7 +933,7 @@ subroutine swigf_argsort__SWIG_4(data, idx, cmp)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT32_T), dimension(:), intent(in), target :: data
 integer(C_INT), dimension(:), target :: idx
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
 type(C_FUNPTR) :: farg5 
@@ -948,7 +948,7 @@ subroutine swigf_argsort__SWIG_5(data, idx, cmp)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT64_T), dimension(:), intent(in), target :: data
 integer(C_INT), dimension(:), target :: idx
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
 type(C_FUNPTR) :: farg5 
@@ -963,7 +963,7 @@ subroutine swigf_argsort__SWIG_6(data, idx, cmp)
 use, intrinsic :: ISO_C_BINDING
 real(C_DOUBLE), dimension(:), intent(in), target :: data
 integer(C_INT), dimension(:), target :: idx
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
 type(C_FUNPTR) :: farg5 
@@ -979,7 +979,7 @@ use, intrinsic :: ISO_C_BINDING
 class(SWIGTYPE_p_p_void), intent(in) :: data
 integer(C_SIZE_T), intent(in) :: datasize
 integer(C_INT), dimension(:), target :: idx
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 type(SwigClassWrapper) :: farg1 
 integer(C_SIZE_T) :: farg2 
 type(SwigArrayWrapper) :: farg3 
@@ -1046,7 +1046,7 @@ use, intrinsic :: ISO_C_BINDING
 integer(INDEX_INT) :: swig_result
 integer(C_INT32_T), dimension(:), intent(in), target :: data
 integer(C_INT32_T), intent(in) :: value
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 integer(C_INT32_T) :: farg3 
@@ -1065,7 +1065,7 @@ use, intrinsic :: ISO_C_BINDING
 integer(INDEX_INT) :: swig_result
 integer(C_INT64_T), dimension(:), intent(in), target :: data
 integer(C_INT64_T), intent(in) :: value
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 integer(C_INT64_T) :: farg3 
@@ -1084,7 +1084,7 @@ use, intrinsic :: ISO_C_BINDING
 integer(INDEX_INT) :: swig_result
 real(C_DOUBLE), dimension(:), intent(in), target :: data
 real(C_DOUBLE), intent(in) :: value
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 real(C_DOUBLE) :: farg3 
@@ -1104,7 +1104,7 @@ integer(INDEX_INT) :: swig_result
 class(SWIGTYPE_p_p_void), intent(in) :: data
 integer(C_SIZE_T), intent(in) :: datasize
 type(C_PTR), intent(in) :: value
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 integer(C_INT) :: fresult 
 type(SwigClassWrapper) :: farg1 
 integer(C_SIZE_T) :: farg2 
@@ -1179,7 +1179,7 @@ integer(C_INT32_T), dimension(:), intent(in), target :: data
 integer(C_INT32_T), intent(in) :: value
 integer(INDEX_INT), target, intent(inout) :: first_index
 integer(INDEX_INT), target, intent(inout) :: last_index
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 integer(C_INT32_T) :: farg3 
 type(C_PTR) :: farg4 
@@ -1200,7 +1200,7 @@ integer(C_INT64_T), dimension(:), intent(in), target :: data
 integer(C_INT64_T), intent(in) :: value
 integer(INDEX_INT), target, intent(inout) :: first_index
 integer(INDEX_INT), target, intent(inout) :: last_index
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 integer(C_INT64_T) :: farg3 
 type(C_PTR) :: farg4 
@@ -1221,7 +1221,7 @@ real(C_DOUBLE), dimension(:), intent(in), target :: data
 real(C_DOUBLE), intent(in) :: value
 integer(INDEX_INT), target, intent(inout) :: first_index
 integer(INDEX_INT), target, intent(inout) :: last_index
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 type(SwigArrayWrapper) :: farg1 
 real(C_DOUBLE) :: farg3 
 type(C_PTR) :: farg4 
@@ -1243,7 +1243,7 @@ integer(C_SIZE_T), intent(in) :: datasize
 type(C_PTR), intent(in) :: value
 integer(INDEX_INT), target, intent(inout) :: first_index
 integer(INDEX_INT), target, intent(inout) :: last_index
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 type(SwigClassWrapper) :: farg1 
 integer(C_SIZE_T) :: farg2 
 type(C_PTR) :: farg3 
@@ -1310,7 +1310,7 @@ use, intrinsic :: ISO_C_BINDING
 integer(C_INT32_T), dimension(:), intent(in), target :: data
 integer(INDEX_INT), target, intent(inout) :: min_index
 integer(INDEX_INT), target, intent(inout) :: max_index
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_PTR) :: farg3 
 type(C_PTR) :: farg4 
@@ -1328,7 +1328,7 @@ use, intrinsic :: ISO_C_BINDING
 integer(C_INT64_T), dimension(:), intent(in), target :: data
 integer(INDEX_INT), target, intent(inout) :: min_index
 integer(INDEX_INT), target, intent(inout) :: max_index
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_PTR) :: farg3 
 type(C_PTR) :: farg4 
@@ -1346,7 +1346,7 @@ use, intrinsic :: ISO_C_BINDING
 real(C_DOUBLE), dimension(:), intent(in), target :: data
 integer(INDEX_INT), target, intent(inout) :: min_index
 integer(INDEX_INT), target, intent(inout) :: max_index
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 type(SwigArrayWrapper) :: farg1 
 type(C_PTR) :: farg3 
 type(C_PTR) :: farg4 
@@ -1365,7 +1365,7 @@ class(SWIGTYPE_p_p_void), intent(in) :: data
 integer(C_SIZE_T), intent(in) :: datasize
 integer(INDEX_INT), target, intent(inout) :: min_index
 integer(INDEX_INT), target, intent(inout) :: max_index
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 type(SwigClassWrapper) :: farg1 
 integer(C_SIZE_T) :: farg2 
 type(C_PTR) :: farg3 
@@ -1434,7 +1434,7 @@ use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 integer(C_INT32_T), dimension(:), intent(in), target :: data1
 integer(C_INT32_T), dimension(:), intent(in), target :: data2
-procedure(SWIG_cmp_funptr_int32_t) :: cmp
+procedure(flc_cmp_funptr_int32_t) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
@@ -1453,7 +1453,7 @@ use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 integer(C_INT64_T), dimension(:), intent(in), target :: data1
 integer(C_INT64_T), dimension(:), intent(in), target :: data2
-procedure(SWIG_cmp_funptr_int64_t) :: cmp
+procedure(flc_cmp_funptr_int64_t) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
@@ -1472,7 +1472,7 @@ use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
 real(C_DOUBLE), dimension(:), intent(in), target :: data1
 real(C_DOUBLE), dimension(:), intent(in), target :: data2
-procedure(SWIG_cmp_funptr_double) :: cmp
+procedure(flc_cmp_funptr_double) :: cmp
 integer(C_INT) :: fresult 
 type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
@@ -1493,7 +1493,7 @@ class(SWIGTYPE_p_p_void), intent(in) :: data1
 integer(C_SIZE_T), intent(in) :: datasize1
 class(SWIGTYPE_p_p_void), intent(in) :: data2
 integer(C_SIZE_T), intent(in) :: datasize2
-procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+procedure(flc_cmp_funptr_void_Sm_) :: cmp
 integer(C_INT) :: fresult 
 type(SwigClassWrapper) :: farg1 
 integer(C_SIZE_T) :: farg2 

--- a/src/flc_algorithm.f90
+++ b/src/flc_algorithm.f90
@@ -216,13 +216,12 @@ type(C_FUNPTR), value :: farg3
 integer(C_INT) :: fresult
 end function
 
-function swigc_is_sorted__SWIG_7(farg1, farg2, farg3) &
+function swigc_is_sorted__SWIG_7(farg1, farg3) &
 bind(C, name="_wrap_is_sorted__SWIG_7") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
-import :: swigclasswrapper
-type(SwigClassWrapper) :: farg1
-integer(C_SIZE_T), intent(in) :: farg2
+import :: swigarraywrapper
+type(SwigArrayWrapper) :: farg1
 type(C_FUNPTR), value :: farg3
 integer(C_INT) :: fresult
 end function
@@ -278,13 +277,11 @@ type(SwigArrayWrapper) :: farg3
 type(C_FUNPTR), value :: farg5
 end subroutine
 
-subroutine swigc_argsort__SWIG_7(farg1, farg2, farg3, farg5) &
+subroutine swigc_argsort__SWIG_7(farg1, farg3, farg5) &
 bind(C, name="_wrap_argsort__SWIG_7")
 use, intrinsic :: ISO_C_BINDING
-import :: swigclasswrapper
 import :: swigarraywrapper
-type(SwigClassWrapper) :: farg1
-integer(C_SIZE_T), intent(in) :: farg2
+type(SwigArrayWrapper) :: farg1
 type(SwigArrayWrapper) :: farg3
 type(C_FUNPTR), value :: farg5
 end subroutine
@@ -352,13 +349,12 @@ type(C_FUNPTR), value :: farg4
 integer(C_INT) :: fresult
 end function
 
-function swigc_binary_search__SWIG_7(farg1, farg2, farg3, farg4) &
+function swigc_binary_search__SWIG_7(farg1, farg3, farg4) &
 bind(C, name="_wrap_binary_search__SWIG_7") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
-import :: swigclasswrapper
-type(SwigClassWrapper) :: farg1
-integer(C_SIZE_T), intent(in) :: farg2
+import :: swigarraywrapper
+type(SwigArrayWrapper) :: farg1
 type(C_PTR), intent(in) :: farg3
 type(C_FUNPTR), value :: farg4
 integer(C_INT) :: fresult
@@ -427,12 +423,11 @@ type(C_PTR), value :: farg5
 type(C_FUNPTR), value :: farg6
 end subroutine
 
-subroutine swigc_equal_range__SWIG_7(farg1, farg2, farg3, farg4, farg5, farg6) &
+subroutine swigc_equal_range__SWIG_7(farg1, farg3, farg4, farg5, farg6) &
 bind(C, name="_wrap_equal_range__SWIG_7")
 use, intrinsic :: ISO_C_BINDING
-import :: swigclasswrapper
-type(SwigClassWrapper) :: farg1
-integer(C_SIZE_T), intent(in) :: farg2
+import :: swigarraywrapper
+type(SwigArrayWrapper) :: farg1
 type(C_PTR), intent(in) :: farg3
 type(C_PTR), value :: farg4
 type(C_PTR), value :: farg5
@@ -496,12 +491,11 @@ type(C_PTR), value :: farg4
 type(C_FUNPTR), value :: farg5
 end subroutine
 
-subroutine swigc_minmax_element__SWIG_7(farg1, farg2, farg3, farg4, farg5) &
+subroutine swigc_minmax_element__SWIG_7(farg1, farg3, farg4, farg5) &
 bind(C, name="_wrap_minmax_element__SWIG_7")
 use, intrinsic :: ISO_C_BINDING
-import :: swigclasswrapper
-type(SwigClassWrapper) :: farg1
-integer(C_SIZE_T), intent(in) :: farg2
+import :: swigarraywrapper
+type(SwigArrayWrapper) :: farg1
 type(C_PTR), value :: farg3
 type(C_PTR), value :: farg4
 type(C_FUNPTR), value :: farg5
@@ -859,22 +853,19 @@ fresult = swigc_is_sorted__SWIG_6(farg1, farg3)
 call SWIGTM_fout_bool(fresult, swig_result)
 end function
 
-function swigf_is_sorted__SWIG_7(data, datasize, cmp) &
+function swigf_is_sorted__SWIG_7(data, cmp) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
-class(SWIGTYPE_p_p_void), intent(in) :: data
-integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), dimension(:), intent(in), target :: data
 procedure(flc_cmp_funptr_void_Sm_) :: cmp
 integer(C_INT) :: fresult 
-type(SwigClassWrapper) :: farg1 
-integer(C_SIZE_T) :: farg2 
+type(SwigArrayWrapper) :: farg1 
 type(C_FUNPTR) :: farg3 
 
-farg1 = data%swigdata
-farg2 = datasize
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg1)
 farg3 = c_funloc(cmp)
-fresult = swigc_is_sorted__SWIG_7(farg1, farg2, farg3)
+fresult = swigc_is_sorted__SWIG_7(farg1, farg3)
 call SWIGTM_fout_bool(fresult, swig_result)
 end function
 
@@ -974,22 +965,19 @@ farg5 = c_funloc(cmp)
 call swigc_argsort__SWIG_6(farg1, farg3, farg5)
 end subroutine
 
-subroutine swigf_argsort__SWIG_7(data, datasize, idx, cmp)
+subroutine swigf_argsort__SWIG_7(data, idx, cmp)
 use, intrinsic :: ISO_C_BINDING
-class(SWIGTYPE_p_p_void), intent(in) :: data
-integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), dimension(:), intent(in), target :: data
 integer(C_INT), dimension(:), target :: idx
 procedure(flc_cmp_funptr_void_Sm_) :: cmp
-type(SwigClassWrapper) :: farg1 
-integer(C_SIZE_T) :: farg2 
+type(SwigArrayWrapper) :: farg1 
 type(SwigArrayWrapper) :: farg3 
 type(C_FUNPTR) :: farg5 
 
-farg1 = data%swigdata
-farg2 = datasize
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg1)
 call SWIGTM_fin_int_Sb__SB_(idx, farg3)
 farg5 = c_funloc(cmp)
-call swigc_argsort__SWIG_7(farg1, farg2, farg3, farg5)
+call swigc_argsort__SWIG_7(farg1, farg3, farg5)
 end subroutine
 
 function swigf_binary_search__SWIG_1(data, value) &
@@ -1097,25 +1085,22 @@ fresult = swigc_binary_search__SWIG_6(farg1, farg3, farg4)
 swig_result = fresult
 end function
 
-function swigf_binary_search__SWIG_7(data, datasize, value, cmp) &
+function swigf_binary_search__SWIG_7(data, value, cmp) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 integer(INDEX_INT) :: swig_result
-class(SWIGTYPE_p_p_void), intent(in) :: data
-integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), dimension(:), intent(in), target :: data
 type(C_PTR), intent(in) :: value
 procedure(flc_cmp_funptr_void_Sm_) :: cmp
 integer(C_INT) :: fresult 
-type(SwigClassWrapper) :: farg1 
-integer(C_SIZE_T) :: farg2 
+type(SwigArrayWrapper) :: farg1 
 type(C_PTR) :: farg3 
 type(C_FUNPTR) :: farg4 
 
-farg1 = data%swigdata
-farg2 = datasize
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg1)
 farg3 = value
 farg4 = c_funloc(cmp)
-fresult = swigc_binary_search__SWIG_7(farg1, farg2, farg3, farg4)
+fresult = swigc_binary_search__SWIG_7(farg1, farg3, farg4)
 swig_result = fresult
 end function
 
@@ -1236,28 +1221,25 @@ farg6 = c_funloc(cmp)
 call swigc_equal_range__SWIG_6(farg1, farg3, farg4, farg5, farg6)
 end subroutine
 
-subroutine swigf_equal_range__SWIG_7(data, datasize, value, first_index, last_index, cmp)
+subroutine swigf_equal_range__SWIG_7(data, value, first_index, last_index, cmp)
 use, intrinsic :: ISO_C_BINDING
-class(SWIGTYPE_p_p_void), intent(in) :: data
-integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), dimension(:), intent(in), target :: data
 type(C_PTR), intent(in) :: value
 integer(INDEX_INT), target, intent(inout) :: first_index
 integer(INDEX_INT), target, intent(inout) :: last_index
 procedure(flc_cmp_funptr_void_Sm_) :: cmp
-type(SwigClassWrapper) :: farg1 
-integer(C_SIZE_T) :: farg2 
+type(SwigArrayWrapper) :: farg1 
 type(C_PTR) :: farg3 
 type(C_PTR) :: farg4 
 type(C_PTR) :: farg5 
 type(C_FUNPTR) :: farg6 
 
-farg1 = data%swigdata
-farg2 = datasize
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg1)
 farg3 = value
 farg4 = c_loc(first_index)
 farg5 = c_loc(last_index)
 farg6 = c_funloc(cmp)
-call swigc_equal_range__SWIG_7(farg1, farg2, farg3, farg4, farg5, farg6)
+call swigc_equal_range__SWIG_7(farg1, farg3, farg4, farg5, farg6)
 end subroutine
 
 subroutine swigf_minmax_element__SWIG_1(data, min_index, max_index)
@@ -1359,25 +1341,22 @@ farg5 = c_funloc(cmp)
 call swigc_minmax_element__SWIG_6(farg1, farg3, farg4, farg5)
 end subroutine
 
-subroutine swigf_minmax_element__SWIG_7(data, datasize, min_index, max_index, cmp)
+subroutine swigf_minmax_element__SWIG_7(data, min_index, max_index, cmp)
 use, intrinsic :: ISO_C_BINDING
-class(SWIGTYPE_p_p_void), intent(in) :: data
-integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), dimension(:), intent(in), target :: data
 integer(INDEX_INT), target, intent(inout) :: min_index
 integer(INDEX_INT), target, intent(inout) :: max_index
 procedure(flc_cmp_funptr_void_Sm_) :: cmp
-type(SwigClassWrapper) :: farg1 
-integer(C_SIZE_T) :: farg2 
+type(SwigArrayWrapper) :: farg1 
 type(C_PTR) :: farg3 
 type(C_PTR) :: farg4 
 type(C_FUNPTR) :: farg5 
 
-farg1 = data%swigdata
-farg2 = datasize
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg1)
 farg3 = c_loc(min_index)
 farg4 = c_loc(max_index)
 farg5 = c_funloc(cmp)
-call swigc_minmax_element__SWIG_7(farg1, farg2, farg3, farg4, farg5)
+call swigc_minmax_element__SWIG_7(farg1, farg3, farg4, farg5)
 end subroutine
 
 function swigf_includes__SWIG_1(data1, data2) &

--- a/src/flc_algorithm.f90
+++ b/src/flc_algorithm.f90
@@ -61,9 +61,6 @@ integer, parameter, public :: INDEX_INT = C_INT
   type(C_PTR), public :: cptr = C_NULL_PTR
   integer(C_INT), public :: cmemflags = 0
  end type
- type, public :: SWIGTYPE_p_p_void
-  type(SwigClassWrapper), public :: swigdata
- end type
  interface binary_search
   module procedure swigf_binary_search__SWIG_1, swigf_binary_search__SWIG_2, swigf_binary_search__SWIG_3, &
     swigf_binary_search__SWIG_4, swigf_binary_search__SWIG_5, swigf_binary_search__SWIG_6, swigf_binary_search__SWIG_7
@@ -564,15 +561,13 @@ type(C_FUNPTR), value :: farg5
 integer(C_INT) :: fresult
 end function
 
-function swigc_includes__SWIG_7(farg1, farg2, farg3, farg4, farg5) &
+function swigc_includes__SWIG_7(farg1, farg3, farg5) &
 bind(C, name="_wrap_includes__SWIG_7") &
 result(fresult)
 use, intrinsic :: ISO_C_BINDING
-import :: swigclasswrapper
-type(SwigClassWrapper) :: farg1
-integer(C_SIZE_T), intent(in) :: farg2
-type(SwigClassWrapper) :: farg3
-integer(C_SIZE_T), intent(in) :: farg4
+import :: swigarraywrapper
+type(SwigArrayWrapper) :: farg1
+type(SwigArrayWrapper) :: farg3
 type(C_FUNPTR), value :: farg5
 integer(C_INT) :: fresult
 end function
@@ -1464,28 +1459,22 @@ fresult = swigc_includes__SWIG_6(farg1, farg3, farg5)
 call SWIGTM_fout_bool(fresult, swig_result)
 end function
 
-function swigf_includes__SWIG_7(data1, datasize1, data2, datasize2, cmp) &
+function swigf_includes__SWIG_7(data1, data2, cmp) &
 result(swig_result)
 use, intrinsic :: ISO_C_BINDING
 logical :: swig_result
-class(SWIGTYPE_p_p_void), intent(in) :: data1
-integer(C_SIZE_T), intent(in) :: datasize1
-class(SWIGTYPE_p_p_void), intent(in) :: data2
-integer(C_SIZE_T), intent(in) :: datasize2
+type(C_PTR), dimension(:), intent(in), target :: data1
+type(C_PTR), dimension(:), intent(in), target :: data2
 procedure(flc_cmp_funptr_void_Sm_) :: cmp
 integer(C_INT) :: fresult 
-type(SwigClassWrapper) :: farg1 
-integer(C_SIZE_T) :: farg2 
-type(SwigClassWrapper) :: farg3 
-integer(C_SIZE_T) :: farg4 
+type(SwigArrayWrapper) :: farg1 
+type(SwigArrayWrapper) :: farg3 
 type(C_FUNPTR) :: farg5 
 
-farg1 = data1%swigdata
-farg2 = datasize1
-farg3 = data2%swigdata
-farg4 = datasize2
+call SWIGTM_fin_void_Sm__Sb__SB_(data1, farg1)
+call SWIGTM_fin_void_Sm__Sb__SB_(data2, farg3)
 farg5 = c_funloc(cmp)
-fresult = swigc_includes__SWIG_7(farg1, farg2, farg3, farg4, farg5)
+fresult = swigc_includes__SWIG_7(farg1, farg3, farg5)
 call SWIGTM_fout_bool(fresult, swig_result)
 end function
 

--- a/src/flc_algorithm.f90
+++ b/src/flc_algorithm.f90
@@ -46,6 +46,14 @@ integer, parameter, public :: INDEX_INT = C_INT
      logical(C_BOOL) :: fresult
    end function
  end interface
+ abstract interface
+   function SWIG_cmp_funptr_void_Sm_(left, right) bind(C) &
+       result(fresult)
+     use, intrinsic :: ISO_C_BINDING
+     type(C_PTR), intent(in), value :: left, right
+     logical(C_BOOL) :: fresult
+   end function
+ end interface
 
  integer, parameter :: swig_cmem_own_bit = 0
  integer, parameter :: swig_cmem_rvalue_bit = 1
@@ -53,43 +61,46 @@ integer, parameter, public :: INDEX_INT = C_INT
   type(C_PTR), public :: cptr = C_NULL_PTR
   integer(C_INT), public :: cmemflags = 0
  end type
+ type, public :: SWIGTYPE_p_p_void
+  type(SwigClassWrapper), public :: swigdata
+ end type
  interface binary_search
   module procedure swigf_binary_search__SWIG_1, swigf_binary_search__SWIG_2, swigf_binary_search__SWIG_3, &
-    swigf_binary_search__SWIG_4, swigf_binary_search__SWIG_5, swigf_binary_search__SWIG_6
+    swigf_binary_search__SWIG_4, swigf_binary_search__SWIG_5, swigf_binary_search__SWIG_6, swigf_binary_search__SWIG_7
  end interface
  public :: binary_search
  interface minmax_element
   module procedure swigf_minmax_element__SWIG_1, swigf_minmax_element__SWIG_2, swigf_minmax_element__SWIG_3, &
-    swigf_minmax_element__SWIG_4, swigf_minmax_element__SWIG_5, swigf_minmax_element__SWIG_6
+    swigf_minmax_element__SWIG_4, swigf_minmax_element__SWIG_5, swigf_minmax_element__SWIG_6, swigf_minmax_element__SWIG_7
  end interface
  public :: minmax_element
  interface shuffle
-  module procedure swigf_shuffle__SWIG_1, swigf_shuffle__SWIG_2, swigf_shuffle__SWIG_3
+  module procedure swigf_shuffle__SWIG_1, swigf_shuffle__SWIG_2, swigf_shuffle__SWIG_3, swigf_shuffle__SWIG_4
  end interface
  public :: shuffle
  interface includes
   module procedure swigf_includes__SWIG_1, swigf_includes__SWIG_2, swigf_includes__SWIG_3, swigf_includes__SWIG_4, &
-    swigf_includes__SWIG_5, swigf_includes__SWIG_6
+    swigf_includes__SWIG_5, swigf_includes__SWIG_6, swigf_includes__SWIG_7
  end interface
  public :: includes
  interface is_sorted
   module procedure swigf_is_sorted__SWIG_1, swigf_is_sorted__SWIG_2, swigf_is_sorted__SWIG_3, swigf_is_sorted__SWIG_4, &
-    swigf_is_sorted__SWIG_5, swigf_is_sorted__SWIG_6
+    swigf_is_sorted__SWIG_5, swigf_is_sorted__SWIG_6, swigf_is_sorted__SWIG_7
  end interface
  public :: is_sorted
  interface equal_range
   module procedure swigf_equal_range__SWIG_1, swigf_equal_range__SWIG_2, swigf_equal_range__SWIG_3, swigf_equal_range__SWIG_4, &
-    swigf_equal_range__SWIG_5, swigf_equal_range__SWIG_6
+    swigf_equal_range__SWIG_5, swigf_equal_range__SWIG_6, swigf_equal_range__SWIG_7
  end interface
  public :: equal_range
  interface sort
   module procedure swigf_sort__SWIG_1, swigf_sort__SWIG_2, swigf_sort__SWIG_3, swigf_sort__SWIG_4, swigf_sort__SWIG_5, &
-    swigf_sort__SWIG_6
+    swigf_sort__SWIG_6, swigf_sort__SWIG_7
  end interface
  public :: sort
  interface argsort
   module procedure swigf_argsort__SWIG_1, swigf_argsort__SWIG_2, swigf_argsort__SWIG_3, swigf_argsort__SWIG_4, &
-    swigf_argsort__SWIG_5, swigf_argsort__SWIG_6
+    swigf_argsort__SWIG_5, swigf_argsort__SWIG_6, swigf_argsort__SWIG_7
  end interface
  public :: argsort
 
@@ -134,6 +145,14 @@ end subroutine
 
 subroutine swigc_sort__SWIG_6(farg1, farg3) &
 bind(C, name="_wrap_sort__SWIG_6")
+use, intrinsic :: ISO_C_BINDING
+import :: swigarraywrapper
+type(SwigArrayWrapper) :: farg1
+type(C_FUNPTR), value :: farg3
+end subroutine
+
+subroutine swigc_sort__SWIG_7(farg1, farg3) &
+bind(C, name="_wrap_sort__SWIG_7")
 use, intrinsic :: ISO_C_BINDING
 import :: swigarraywrapper
 type(SwigArrayWrapper) :: farg1
@@ -197,6 +216,17 @@ type(C_FUNPTR), value :: farg3
 integer(C_INT) :: fresult
 end function
 
+function swigc_is_sorted__SWIG_7(farg1, farg2, farg3) &
+bind(C, name="_wrap_is_sorted__SWIG_7") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+type(SwigClassWrapper) :: farg1
+integer(C_SIZE_T), intent(in) :: farg2
+type(C_FUNPTR), value :: farg3
+integer(C_INT) :: fresult
+end function
+
 subroutine swigc_argsort__SWIG_1(farg1, farg3) &
 bind(C, name="_wrap_argsort__SWIG_1")
 use, intrinsic :: ISO_C_BINDING
@@ -244,6 +274,17 @@ bind(C, name="_wrap_argsort__SWIG_6")
 use, intrinsic :: ISO_C_BINDING
 import :: swigarraywrapper
 type(SwigArrayWrapper) :: farg1
+type(SwigArrayWrapper) :: farg3
+type(C_FUNPTR), value :: farg5
+end subroutine
+
+subroutine swigc_argsort__SWIG_7(farg1, farg2, farg3, farg5) &
+bind(C, name="_wrap_argsort__SWIG_7")
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+import :: swigarraywrapper
+type(SwigClassWrapper) :: farg1
+integer(C_SIZE_T), intent(in) :: farg2
 type(SwigArrayWrapper) :: farg3
 type(C_FUNPTR), value :: farg5
 end subroutine
@@ -311,6 +352,18 @@ type(C_FUNPTR), value :: farg4
 integer(C_INT) :: fresult
 end function
 
+function swigc_binary_search__SWIG_7(farg1, farg2, farg3, farg4) &
+bind(C, name="_wrap_binary_search__SWIG_7") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+type(SwigClassWrapper) :: farg1
+integer(C_SIZE_T), intent(in) :: farg2
+type(C_PTR), intent(in) :: farg3
+type(C_FUNPTR), value :: farg4
+integer(C_INT) :: fresult
+end function
+
 subroutine swigc_equal_range__SWIG_1(farg1, farg3, farg4, farg5) &
 bind(C, name="_wrap_equal_range__SWIG_1")
 use, intrinsic :: ISO_C_BINDING
@@ -374,6 +427,18 @@ type(C_PTR), value :: farg5
 type(C_FUNPTR), value :: farg6
 end subroutine
 
+subroutine swigc_equal_range__SWIG_7(farg1, farg2, farg3, farg4, farg5, farg6) &
+bind(C, name="_wrap_equal_range__SWIG_7")
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+type(SwigClassWrapper) :: farg1
+integer(C_SIZE_T), intent(in) :: farg2
+type(C_PTR), intent(in) :: farg3
+type(C_PTR), value :: farg4
+type(C_PTR), value :: farg5
+type(C_FUNPTR), value :: farg6
+end subroutine
+
 subroutine swigc_minmax_element__SWIG_1(farg1, farg3, farg4) &
 bind(C, name="_wrap_minmax_element__SWIG_1")
 use, intrinsic :: ISO_C_BINDING
@@ -426,6 +491,17 @@ bind(C, name="_wrap_minmax_element__SWIG_6")
 use, intrinsic :: ISO_C_BINDING
 import :: swigarraywrapper
 type(SwigArrayWrapper) :: farg1
+type(C_PTR), value :: farg3
+type(C_PTR), value :: farg4
+type(C_FUNPTR), value :: farg5
+end subroutine
+
+subroutine swigc_minmax_element__SWIG_7(farg1, farg2, farg3, farg4, farg5) &
+bind(C, name="_wrap_minmax_element__SWIG_7")
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+type(SwigClassWrapper) :: farg1
+integer(C_SIZE_T), intent(in) :: farg2
 type(C_PTR), value :: farg3
 type(C_PTR), value :: farg4
 type(C_FUNPTR), value :: farg5
@@ -494,6 +570,19 @@ type(C_FUNPTR), value :: farg5
 integer(C_INT) :: fresult
 end function
 
+function swigc_includes__SWIG_7(farg1, farg2, farg3, farg4, farg5) &
+bind(C, name="_wrap_includes__SWIG_7") &
+result(fresult)
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+type(SwigClassWrapper) :: farg1
+integer(C_SIZE_T), intent(in) :: farg2
+type(SwigClassWrapper) :: farg3
+integer(C_SIZE_T), intent(in) :: farg4
+type(C_FUNPTR), value :: farg5
+integer(C_INT) :: fresult
+end function
+
 subroutine swigc_shuffle__SWIG_1(farg1, farg2) &
 bind(C, name="_wrap_shuffle__SWIG_1")
 use, intrinsic :: ISO_C_BINDING
@@ -514,6 +603,15 @@ end subroutine
 
 subroutine swigc_shuffle__SWIG_3(farg1, farg2) &
 bind(C, name="_wrap_shuffle__SWIG_3")
+use, intrinsic :: ISO_C_BINDING
+import :: swigclasswrapper
+import :: swigarraywrapper
+type(SwigClassWrapper) :: farg1
+type(SwigArrayWrapper) :: farg2
+end subroutine
+
+subroutine swigc_shuffle__SWIG_4(farg1, farg2) &
+bind(C, name="_wrap_shuffle__SWIG_4")
 use, intrinsic :: ISO_C_BINDING
 import :: swigclasswrapper
 import :: swigarraywrapper
@@ -634,6 +732,33 @@ farg3 = c_funloc(cmp)
 call swigc_sort__SWIG_6(farg1, farg3)
 end subroutine
 
+subroutine SWIGTM_fin_void_Sm__Sb__SB_(finp, iminp)
+  use, intrinsic :: ISO_C_BINDING
+  type(C_PTR), dimension(:), intent(in), target :: finp
+  type(SwigArrayWrapper), intent(out) :: iminp
+  type(C_PTR), pointer :: imtemp
+
+  if (size(finp) > 0) then
+    imtemp => finp(1)
+    iminp%data = c_loc(imtemp)
+    iminp%size = size(finp)
+  else
+    iminp%data = c_null_ptr
+    iminp%size = 0
+  end if
+end subroutine
+subroutine swigf_sort__SWIG_7(data, cmp)
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), dimension(:), target :: data
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+type(SwigArrayWrapper) :: farg1 
+type(C_FUNPTR) :: farg3 
+
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg1)
+farg3 = c_funloc(cmp)
+call swigc_sort__SWIG_7(farg1, farg3)
+end subroutine
+
 
 subroutine SWIGTM_fout_bool(imout, fout)
   use, intrinsic :: ISO_C_BINDING
@@ -734,6 +859,25 @@ fresult = swigc_is_sorted__SWIG_6(farg1, farg3)
 call SWIGTM_fout_bool(fresult, swig_result)
 end function
 
+function swigf_is_sorted__SWIG_7(data, datasize, cmp) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+logical :: swig_result
+class(SWIGTYPE_p_p_void), intent(in) :: data
+integer(C_SIZE_T), intent(in) :: datasize
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+integer(C_INT) :: fresult 
+type(SwigClassWrapper) :: farg1 
+integer(C_SIZE_T) :: farg2 
+type(C_FUNPTR) :: farg3 
+
+farg1 = data%swigdata
+farg2 = datasize
+farg3 = c_funloc(cmp)
+fresult = swigc_is_sorted__SWIG_7(farg1, farg2, farg3)
+call SWIGTM_fout_bool(fresult, swig_result)
+end function
+
 subroutine SWIGTM_fin_int_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT), dimension(:), intent(in), target :: finp
@@ -828,6 +972,24 @@ call SWIGTM_fin_double_Sb__SB_(data, farg1)
 call SWIGTM_fin_int_Sb__SB_(idx, farg3)
 farg5 = c_funloc(cmp)
 call swigc_argsort__SWIG_6(farg1, farg3, farg5)
+end subroutine
+
+subroutine swigf_argsort__SWIG_7(data, datasize, idx, cmp)
+use, intrinsic :: ISO_C_BINDING
+class(SWIGTYPE_p_p_void), intent(in) :: data
+integer(C_SIZE_T), intent(in) :: datasize
+integer(C_INT), dimension(:), target :: idx
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+type(SwigClassWrapper) :: farg1 
+integer(C_SIZE_T) :: farg2 
+type(SwigArrayWrapper) :: farg3 
+type(C_FUNPTR) :: farg5 
+
+farg1 = data%swigdata
+farg2 = datasize
+call SWIGTM_fin_int_Sb__SB_(idx, farg3)
+farg5 = c_funloc(cmp)
+call swigc_argsort__SWIG_7(farg1, farg2, farg3, farg5)
 end subroutine
 
 function swigf_binary_search__SWIG_1(data, value) &
@@ -932,6 +1094,28 @@ call SWIGTM_fin_double_Sb__SB_(data, farg1)
 farg3 = value
 farg4 = c_funloc(cmp)
 fresult = swigc_binary_search__SWIG_6(farg1, farg3, farg4)
+swig_result = fresult
+end function
+
+function swigf_binary_search__SWIG_7(data, datasize, value, cmp) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+integer(INDEX_INT) :: swig_result
+class(SWIGTYPE_p_p_void), intent(in) :: data
+integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), intent(in) :: value
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+integer(C_INT) :: fresult 
+type(SwigClassWrapper) :: farg1 
+integer(C_SIZE_T) :: farg2 
+type(C_PTR) :: farg3 
+type(C_FUNPTR) :: farg4 
+
+farg1 = data%swigdata
+farg2 = datasize
+farg3 = value
+farg4 = c_funloc(cmp)
+fresult = swigc_binary_search__SWIG_7(farg1, farg2, farg3, farg4)
 swig_result = fresult
 end function
 
@@ -1052,6 +1236,30 @@ farg6 = c_funloc(cmp)
 call swigc_equal_range__SWIG_6(farg1, farg3, farg4, farg5, farg6)
 end subroutine
 
+subroutine swigf_equal_range__SWIG_7(data, datasize, value, first_index, last_index, cmp)
+use, intrinsic :: ISO_C_BINDING
+class(SWIGTYPE_p_p_void), intent(in) :: data
+integer(C_SIZE_T), intent(in) :: datasize
+type(C_PTR), intent(in) :: value
+integer(INDEX_INT), target, intent(inout) :: first_index
+integer(INDEX_INT), target, intent(inout) :: last_index
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+type(SwigClassWrapper) :: farg1 
+integer(C_SIZE_T) :: farg2 
+type(C_PTR) :: farg3 
+type(C_PTR) :: farg4 
+type(C_PTR) :: farg5 
+type(C_FUNPTR) :: farg6 
+
+farg1 = data%swigdata
+farg2 = datasize
+farg3 = value
+farg4 = c_loc(first_index)
+farg5 = c_loc(last_index)
+farg6 = c_funloc(cmp)
+call swigc_equal_range__SWIG_7(farg1, farg2, farg3, farg4, farg5, farg6)
+end subroutine
+
 subroutine swigf_minmax_element__SWIG_1(data, min_index, max_index)
 use, intrinsic :: ISO_C_BINDING
 integer(C_INT32_T), dimension(:), intent(in), target :: data
@@ -1149,6 +1357,27 @@ farg3 = c_loc(min_index)
 farg4 = c_loc(max_index)
 farg5 = c_funloc(cmp)
 call swigc_minmax_element__SWIG_6(farg1, farg3, farg4, farg5)
+end subroutine
+
+subroutine swigf_minmax_element__SWIG_7(data, datasize, min_index, max_index, cmp)
+use, intrinsic :: ISO_C_BINDING
+class(SWIGTYPE_p_p_void), intent(in) :: data
+integer(C_SIZE_T), intent(in) :: datasize
+integer(INDEX_INT), target, intent(inout) :: min_index
+integer(INDEX_INT), target, intent(inout) :: max_index
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+type(SwigClassWrapper) :: farg1 
+integer(C_SIZE_T) :: farg2 
+type(C_PTR) :: farg3 
+type(C_PTR) :: farg4 
+type(C_FUNPTR) :: farg5 
+
+farg1 = data%swigdata
+farg2 = datasize
+farg3 = c_loc(min_index)
+farg4 = c_loc(max_index)
+farg5 = c_funloc(cmp)
+call swigc_minmax_element__SWIG_7(farg1, farg2, farg3, farg4, farg5)
 end subroutine
 
 function swigf_includes__SWIG_1(data1, data2) &
@@ -1256,6 +1485,31 @@ fresult = swigc_includes__SWIG_6(farg1, farg3, farg5)
 call SWIGTM_fout_bool(fresult, swig_result)
 end function
 
+function swigf_includes__SWIG_7(data1, datasize1, data2, datasize2, cmp) &
+result(swig_result)
+use, intrinsic :: ISO_C_BINDING
+logical :: swig_result
+class(SWIGTYPE_p_p_void), intent(in) :: data1
+integer(C_SIZE_T), intent(in) :: datasize1
+class(SWIGTYPE_p_p_void), intent(in) :: data2
+integer(C_SIZE_T), intent(in) :: datasize2
+procedure(SWIG_cmp_funptr_void_Sm_) :: cmp
+integer(C_INT) :: fresult 
+type(SwigClassWrapper) :: farg1 
+integer(C_SIZE_T) :: farg2 
+type(SwigClassWrapper) :: farg3 
+integer(C_SIZE_T) :: farg4 
+type(C_FUNPTR) :: farg5 
+
+farg1 = data1%swigdata
+farg2 = datasize1
+farg3 = data2%swigdata
+farg4 = datasize2
+farg5 = c_funloc(cmp)
+fresult = swigc_includes__SWIG_7(farg1, farg2, farg3, farg4, farg5)
+call SWIGTM_fout_bool(fresult, swig_result)
+end function
+
 subroutine swigf_shuffle__SWIG_1(g, data)
 use, intrinsic :: ISO_C_BINDING
 class(Engine), intent(in) :: g
@@ -1290,6 +1544,18 @@ type(SwigArrayWrapper) :: farg2
 farg1 = g%swigdata
 call SWIGTM_fin_double_Sb__SB_(data, farg2)
 call swigc_shuffle__SWIG_3(farg1, farg2)
+end subroutine
+
+subroutine swigf_shuffle__SWIG_4(g, data)
+use, intrinsic :: ISO_C_BINDING
+class(Engine), intent(in) :: g
+type(C_PTR), dimension(:), target :: data
+type(SwigClassWrapper) :: farg1 
+type(SwigArrayWrapper) :: farg2 
+
+farg1 = g%swigdata
+call SWIGTM_fin_void_Sm__Sb__SB_(data, farg2)
+call swigc_shuffle__SWIG_4(farg1, farg2)
 end subroutine
 
 

--- a/src/flc_algorithmFORTRAN_wrap.cxx
+++ b/src/flc_algorithmFORTRAN_wrap.cxx
@@ -449,6 +449,15 @@ static bool includes_cmp(const T *DATA1,size_t DATASIZE1,const T *DATA2,size_t D
 }
 
 
+#include <random>
+
+
+template<class T>
+static void shuffle(std::mt19937_64& g, T *DATA, size_t DATASIZE) {
+    std::shuffle(DATA, DATA + DATASIZE, g);
+}
+
+
 struct SwigClassWrapper {
     void* cptr;
     int cmemflags;
@@ -460,15 +469,6 @@ SWIGINTERN SwigClassWrapper SwigClassWrapper_uninitialized() {
     result.cptr = NULL;
     result.cmemflags = 0;
     return result;
-}
-
-
-#include <random>
-
-
-template<class T>
-static void shuffle(std::mt19937_64& g, T *DATA, size_t DATASIZE) {
-    std::shuffle(DATA, DATA + DATASIZE, g);
 }
 
 
@@ -1339,7 +1339,7 @@ SWIGEXPORT int _wrap_includes__SWIG_6(SwigArrayWrapper *farg1, SwigArrayWrapper 
 }
 
 
-SWIGEXPORT int _wrap_includes__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, SwigClassWrapper *farg3, size_t const *farg4, bool (*farg5)(void *,void *)) {
+SWIGEXPORT int _wrap_includes__SWIG_7(SwigArrayWrapper *farg1, SwigArrayWrapper *farg3, bool (*farg5)(void *,void *)) {
   int fresult ;
   void **arg1 = (void **) 0 ;
   size_t arg2 ;
@@ -1348,10 +1348,10 @@ SWIGEXPORT int _wrap_includes__SWIG_7(SwigClassWrapper *farg1, size_t const *far
   bool (*arg5)(void *,void *) = (bool (*)(void *,void *)) 0 ;
   bool result;
   
-  arg1 = (void **)farg1->cptr;
-  arg2 = (size_t)(*farg2);
-  arg3 = (void **)farg3->cptr;
-  arg4 = (size_t)(*farg4);
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
+  arg3 = (void **)farg3->data;
+  arg4 = farg3->size;
   arg5 = (bool (*)(void *,void *))(*farg5);
   result = (bool)includes_cmp< void * >((void *const *)arg1,arg2,(void *const *)arg3,arg4,arg5);
   fresult = (result ? 1 : 0);

--- a/src/flc_algorithmFORTRAN_wrap.cxx
+++ b/src/flc_algorithmFORTRAN_wrap.cxx
@@ -339,6 +339,20 @@ static bool is_sorted_cmp(const T *DATA,size_t DATASIZE, bool (*cmp)(T, T)) {
 }
 
 
+struct SwigClassWrapper {
+    void* cptr;
+    int cmemflags;
+};
+
+
+SWIGINTERN SwigClassWrapper SwigClassWrapper_uninitialized() {
+    SwigClassWrapper result;
+    result.cptr = NULL;
+    result.cmemflags = 0;
+    return result;
+}
+
+
 // Operate using default "less than"
 template<class T>
 static void argsort(const T *DATA,size_t DATASIZE,index_int *IDX,size_t IDXSIZE
@@ -354,7 +368,8 @@ static void argsort_cmp(const T *DATA,size_t DATASIZE,index_int *IDX,size_t IDXS
 
 
 template<class T, class Compare>
-static index_int binary_search_impl(const T *data, size_t size, T value, Compare cmp) {
+static index_int binary_search_impl(const T *data, size_t size, T value,
+                                    Compare cmp) {
   const T *end = data + size;
   auto iter = std::lower_bound(data, end, value, cmp);
   if (iter == end || cmp(*iter, value) || cmp(value, *iter))
@@ -364,7 +379,9 @@ static index_int binary_search_impl(const T *data, size_t size, T value, Compare
 }
 
 template<class T, class Compare>
-static void equal_range_impl(const T *data, size_t size, T value, index_int &first_index, index_int &last_index, Compare cmp) {
+static void equal_range_impl(const T *data, size_t size, T value,
+                             index_int &first_index, index_int &last_index,
+                             Compare cmp) {
   const T *end = data + size;
   auto range_pair = std::equal_range(data, end, value, cmp);
   // Index of the min/max items *IN FORTAN INDEXING*
@@ -373,7 +390,9 @@ static void equal_range_impl(const T *data, size_t size, T value, index_int &fir
 }
 
 template<class T, class Compare>
-static void minmax_element_impl(const T *data, size_t size, index_int &min_index, index_int &max_index, Compare cmp) {
+static void minmax_element_impl(const T *data, size_t size,
+                                index_int &min_index, index_int &max_index,
+                                Compare cmp) {
   const T *end = data + size;
   auto mm_pair = std::minmax_element(data, end, cmp);
   // Index of the min/max items *IN FORTAN INDEXING*
@@ -384,14 +403,12 @@ static void minmax_element_impl(const T *data, size_t size, index_int &min_index
 
 // Operate using default "less than"
 template<class T>
-static index_int binary_search(const T *DATA,size_t DATASIZE,T value
-) {
+static index_int binary_search(const T *DATA,size_t DATASIZE,T value) {
   return binary_search_impl(DATA,DATASIZE,value, std::less<T>());
 }
 // Operate using user-provided function pointer
 template<class T>
-static index_int binary_search_cmp(const T *DATA,size_t DATASIZE,T value
-, bool (*cmp)(T, T)) {
+static index_int binary_search_cmp(const T *DATA,size_t DATASIZE,T value, bool (*cmp)(T, T)) {
   return binary_search_impl(DATA,DATASIZE,value, cmp);
 }
 
@@ -399,14 +416,12 @@ static index_int binary_search_cmp(const T *DATA,size_t DATASIZE,T value
 // Operate using default "less than"
 template<class T>
 static void equal_range(const T *DATA,size_t DATASIZE,T value,index_int &first_index,index_int &last_index
-
 ) {
   return equal_range_impl(DATA,DATASIZE,value,first_index,last_index, std::less<T>());
 }
 // Operate using user-provided function pointer
 template<class T>
 static void equal_range_cmp(const T *DATA,size_t DATASIZE,T value,index_int &first_index,index_int &last_index
-
 , bool (*cmp)(T, T)) {
   return equal_range_impl(DATA,DATASIZE,value,first_index,last_index, cmp);
 }
@@ -427,7 +442,9 @@ static void minmax_element_cmp(const T *DATA,size_t DATASIZE,index_int &min_inde
 
 
 template<class T, class Compare>
-static bool includes_impl(const T *data1, size_t size1, const T *data2, size_t size2, Compare cmp) {
+static bool includes_impl(const T *data1, size_t size1,
+                          const T *data2, size_t size2,
+                          Compare cmp) {
   return std::includes(data1, data1 + size1, data2, data2 + size2, cmp);
 }
 
@@ -452,20 +469,6 @@ static bool includes_cmp(const T *DATA1,size_t DATASIZE1,const T *DATA2,size_t D
 template<class T>
 static void shuffle(std::mt19937_64& g, T *DATA, size_t DATASIZE) {
     std::shuffle(DATA, DATA + DATASIZE, g);
-}
-
-
-struct SwigClassWrapper {
-    void* cptr;
-    int cmemflags;
-};
-
-
-SWIGINTERN SwigClassWrapper SwigClassWrapper_uninitialized() {
-    SwigClassWrapper result;
-    result.cptr = NULL;
-    result.cmemflags = 0;
-    return result;
 }
 
 
@@ -652,6 +655,18 @@ SWIGEXPORT void _wrap_sort__SWIG_6(SwigArrayWrapper *farg1, bool (*farg3)(double
 }
 
 
+SWIGEXPORT void _wrap_sort__SWIG_7(SwigArrayWrapper *farg1, bool (*farg3)(void *,void *)) {
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  bool (*arg3)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
+  arg3 = (bool (*)(void *,void *))(*farg3);
+  sort_cmp< void * >(arg1,arg2,arg3);
+}
+
+
 SWIGEXPORT int _wrap_is_sorted__SWIG_1(SwigArrayWrapper *farg1) {
   int fresult ;
   int32_t *arg1 = (int32_t *) 0 ;
@@ -737,6 +752,22 @@ SWIGEXPORT int _wrap_is_sorted__SWIG_6(SwigArrayWrapper *farg1, bool (*farg3)(do
   arg2 = farg1->size;
   arg3 = (bool (*)(double,double))(*farg3);
   result = (bool)is_sorted_cmp< double >((double const *)arg1,arg2,arg3);
+  fresult = (result ? 1 : 0);
+  return fresult;
+}
+
+
+SWIGEXPORT int _wrap_is_sorted__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, bool (*farg3)(void *,void *)) {
+  int fresult ;
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  bool (*arg3)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  bool result;
+  
+  arg1 = (void **)farg1->cptr;
+  arg2 = (size_t)(*farg2);
+  arg3 = (bool (*)(void *,void *))(*farg3);
+  result = (bool)is_sorted_cmp< void * >((void *const *)arg1,arg2,arg3);
   fresult = (result ? 1 : 0);
   return fresult;
 }
@@ -829,6 +860,22 @@ SWIGEXPORT void _wrap_argsort__SWIG_6(SwigArrayWrapper *farg1, SwigArrayWrapper 
   arg4 = farg3->size;
   arg5 = (bool (*)(double,double))(*farg5);
   argsort_cmp< double >((double const *)arg1,arg2,arg3,arg4,arg5);
+}
+
+
+SWIGEXPORT void _wrap_argsort__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, SwigArrayWrapper *farg3, bool (*farg5)(void *,void *)) {
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  index_int *arg3 = (index_int *) 0 ;
+  size_t arg4 ;
+  bool (*arg5)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  
+  arg1 = (void **)farg1->cptr;
+  arg2 = (size_t)(*farg2);
+  arg3 = (index_int *)farg3->data;
+  arg4 = farg3->size;
+  arg5 = (bool (*)(void *,void *))(*farg5);
+  argsort_cmp< void * >((void *const *)arg1,arg2,arg3,arg4,arg5);
 }
 
 
@@ -929,6 +976,24 @@ SWIGEXPORT int _wrap_binary_search__SWIG_6(SwigArrayWrapper *farg1, double const
   arg3 = (double)(*farg3);
   arg4 = (bool (*)(double,double))(*farg4);
   result = (index_int)binary_search_cmp< double >((double const *)arg1,arg2,arg3,arg4);
+  fresult = (index_int)(result);
+  return fresult;
+}
+
+
+SWIGEXPORT int _wrap_binary_search__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, void const **farg3, bool (*farg4)(void *,void *)) {
+  int fresult ;
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  void *arg3 = (void *) 0 ;
+  bool (*arg4)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  index_int result;
+  
+  arg1 = (void **)farg1->cptr;
+  arg2 = (size_t)(*farg2);
+  arg3 = (void *)(*farg3);
+  arg4 = (bool (*)(void *,void *))(*farg4);
+  result = (index_int)binary_search_cmp< void * >((void *const *)arg1,arg2,arg3,arg4);
   fresult = (index_int)(result);
   return fresult;
 }
@@ -1036,6 +1101,24 @@ SWIGEXPORT void _wrap_equal_range__SWIG_6(SwigArrayWrapper *farg1, double const 
 }
 
 
+SWIGEXPORT void _wrap_equal_range__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, void const **farg3, int *farg4, int *farg5, bool (*farg6)(void *,void *)) {
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  void *arg3 = (void *) 0 ;
+  index_int *arg4 = 0 ;
+  index_int *arg5 = 0 ;
+  bool (*arg6)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  
+  arg1 = (void **)farg1->cptr;
+  arg2 = (size_t)(*farg2);
+  arg3 = (void *)(*farg3);
+  arg4 = (index_int *)(farg4);
+  arg5 = (index_int *)(farg5);
+  arg6 = (bool (*)(void *,void *))(*farg6);
+  equal_range_cmp< void * >((void *const *)arg1,arg2,arg3,*arg4,*arg5,arg6);
+}
+
+
 SWIGEXPORT void _wrap_minmax_element__SWIG_1(SwigArrayWrapper *farg1, int *farg3, int *farg4) {
   int32_t *arg1 = (int32_t *) 0 ;
   size_t arg2 ;
@@ -1123,6 +1206,22 @@ SWIGEXPORT void _wrap_minmax_element__SWIG_6(SwigArrayWrapper *farg1, int *farg3
   arg4 = (index_int *)(farg4);
   arg5 = (bool (*)(double,double))(*farg5);
   minmax_element_cmp< double >((double const *)arg1,arg2,*arg3,*arg4,arg5);
+}
+
+
+SWIGEXPORT void _wrap_minmax_element__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, int *farg3, int *farg4, bool (*farg5)(void *,void *)) {
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  index_int *arg3 = 0 ;
+  index_int *arg4 = 0 ;
+  bool (*arg5)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  
+  arg1 = (void **)farg1->cptr;
+  arg2 = (size_t)(*farg2);
+  arg3 = (index_int *)(farg3);
+  arg4 = (index_int *)(farg4);
+  arg5 = (bool (*)(void *,void *))(*farg5);
+  minmax_element_cmp< void * >((void *const *)arg1,arg2,*arg3,*arg4,arg5);
 }
 
 
@@ -1240,6 +1339,26 @@ SWIGEXPORT int _wrap_includes__SWIG_6(SwigArrayWrapper *farg1, SwigArrayWrapper 
 }
 
 
+SWIGEXPORT int _wrap_includes__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, SwigClassWrapper *farg3, size_t const *farg4, bool (*farg5)(void *,void *)) {
+  int fresult ;
+  void **arg1 = (void **) 0 ;
+  size_t arg2 ;
+  void **arg3 = (void **) 0 ;
+  size_t arg4 ;
+  bool (*arg5)(void *,void *) = (bool (*)(void *,void *)) 0 ;
+  bool result;
+  
+  arg1 = (void **)farg1->cptr;
+  arg2 = (size_t)(*farg2);
+  arg3 = (void **)farg3->cptr;
+  arg4 = (size_t)(*farg4);
+  arg5 = (bool (*)(void *,void *))(*farg5);
+  result = (bool)includes_cmp< void * >((void *const *)arg1,arg2,(void *const *)arg3,arg4,arg5);
+  fresult = (result ? 1 : 0);
+  return fresult;
+}
+
+
 SWIGEXPORT void _wrap_shuffle__SWIG_1(SwigClassWrapper *farg1, SwigArrayWrapper *farg2) {
   std::mt19937_64 *arg1 = 0 ;
   int32_t *arg2 = (int32_t *) 0 ;
@@ -1278,6 +1397,20 @@ SWIGEXPORT void _wrap_shuffle__SWIG_3(SwigClassWrapper *farg1, SwigArrayWrapper 
   arg2 = (double *)farg2->data;
   arg3 = farg2->size;
   shuffle< double >(*arg1,arg2,arg3);
+  SWIG_free_rvalue< std::mt19937_64, SWIGPOLICY_std_mt19937_64 >(*farg1);
+}
+
+
+SWIGEXPORT void _wrap_shuffle__SWIG_4(SwigClassWrapper *farg1, SwigArrayWrapper *farg2) {
+  std::mt19937_64 *arg1 = 0 ;
+  void **arg2 = (void **) 0 ;
+  size_t arg3 ;
+  
+  SWIG_check_nonnull(*farg1, "std::mt19937_64 &", "Engine", "shuffle< void * >(std::mt19937_64 &,void **,size_t)", return );
+  arg1 = (std::mt19937_64 *)farg1->cptr;
+  arg2 = (void **)farg2->data;
+  arg3 = farg2->size;
+  shuffle< void * >(*arg1,arg2,arg3);
   SWIG_free_rvalue< std::mt19937_64, SWIGPOLICY_std_mt19937_64 >(*farg1);
 }
 

--- a/src/flc_algorithmFORTRAN_wrap.cxx
+++ b/src/flc_algorithmFORTRAN_wrap.cxx
@@ -339,20 +339,6 @@ static bool is_sorted_cmp(const T *DATA,size_t DATASIZE, bool (*cmp)(T, T)) {
 }
 
 
-struct SwigClassWrapper {
-    void* cptr;
-    int cmemflags;
-};
-
-
-SWIGINTERN SwigClassWrapper SwigClassWrapper_uninitialized() {
-    SwigClassWrapper result;
-    result.cptr = NULL;
-    result.cmemflags = 0;
-    return result;
-}
-
-
 // Operate using default "less than"
 template<class T>
 static void argsort(const T *DATA,size_t DATASIZE,index_int *IDX,size_t IDXSIZE
@@ -460,6 +446,20 @@ template<class T>
 static bool includes_cmp(const T *DATA1,size_t DATASIZE1,const T *DATA2,size_t DATASIZE2
 , bool (*cmp)(T, T)) {
   return includes_impl(DATA1,DATASIZE1,DATA2,DATASIZE2, cmp);
+}
+
+
+struct SwigClassWrapper {
+    void* cptr;
+    int cmemflags;
+};
+
+
+SWIGINTERN SwigClassWrapper SwigClassWrapper_uninitialized() {
+    SwigClassWrapper result;
+    result.cptr = NULL;
+    result.cmemflags = 0;
+    return result;
 }
 
 
@@ -757,15 +757,15 @@ SWIGEXPORT int _wrap_is_sorted__SWIG_6(SwigArrayWrapper *farg1, bool (*farg3)(do
 }
 
 
-SWIGEXPORT int _wrap_is_sorted__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, bool (*farg3)(void *,void *)) {
+SWIGEXPORT int _wrap_is_sorted__SWIG_7(SwigArrayWrapper *farg1, bool (*farg3)(void *,void *)) {
   int fresult ;
   void **arg1 = (void **) 0 ;
   size_t arg2 ;
   bool (*arg3)(void *,void *) = (bool (*)(void *,void *)) 0 ;
   bool result;
   
-  arg1 = (void **)farg1->cptr;
-  arg2 = (size_t)(*farg2);
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
   arg3 = (bool (*)(void *,void *))(*farg3);
   result = (bool)is_sorted_cmp< void * >((void *const *)arg1,arg2,arg3);
   fresult = (result ? 1 : 0);
@@ -863,15 +863,15 @@ SWIGEXPORT void _wrap_argsort__SWIG_6(SwigArrayWrapper *farg1, SwigArrayWrapper 
 }
 
 
-SWIGEXPORT void _wrap_argsort__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, SwigArrayWrapper *farg3, bool (*farg5)(void *,void *)) {
+SWIGEXPORT void _wrap_argsort__SWIG_7(SwigArrayWrapper *farg1, SwigArrayWrapper *farg3, bool (*farg5)(void *,void *)) {
   void **arg1 = (void **) 0 ;
   size_t arg2 ;
   index_int *arg3 = (index_int *) 0 ;
   size_t arg4 ;
   bool (*arg5)(void *,void *) = (bool (*)(void *,void *)) 0 ;
   
-  arg1 = (void **)farg1->cptr;
-  arg2 = (size_t)(*farg2);
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
   arg3 = (index_int *)farg3->data;
   arg4 = farg3->size;
   arg5 = (bool (*)(void *,void *))(*farg5);
@@ -981,7 +981,7 @@ SWIGEXPORT int _wrap_binary_search__SWIG_6(SwigArrayWrapper *farg1, double const
 }
 
 
-SWIGEXPORT int _wrap_binary_search__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, void const **farg3, bool (*farg4)(void *,void *)) {
+SWIGEXPORT int _wrap_binary_search__SWIG_7(SwigArrayWrapper *farg1, void const **farg3, bool (*farg4)(void *,void *)) {
   int fresult ;
   void **arg1 = (void **) 0 ;
   size_t arg2 ;
@@ -989,8 +989,8 @@ SWIGEXPORT int _wrap_binary_search__SWIG_7(SwigClassWrapper *farg1, size_t const
   bool (*arg4)(void *,void *) = (bool (*)(void *,void *)) 0 ;
   index_int result;
   
-  arg1 = (void **)farg1->cptr;
-  arg2 = (size_t)(*farg2);
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
   arg3 = (void *)(*farg3);
   arg4 = (bool (*)(void *,void *))(*farg4);
   result = (index_int)binary_search_cmp< void * >((void *const *)arg1,arg2,arg3,arg4);
@@ -1101,7 +1101,7 @@ SWIGEXPORT void _wrap_equal_range__SWIG_6(SwigArrayWrapper *farg1, double const 
 }
 
 
-SWIGEXPORT void _wrap_equal_range__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, void const **farg3, int *farg4, int *farg5, bool (*farg6)(void *,void *)) {
+SWIGEXPORT void _wrap_equal_range__SWIG_7(SwigArrayWrapper *farg1, void const **farg3, int *farg4, int *farg5, bool (*farg6)(void *,void *)) {
   void **arg1 = (void **) 0 ;
   size_t arg2 ;
   void *arg3 = (void *) 0 ;
@@ -1109,8 +1109,8 @@ SWIGEXPORT void _wrap_equal_range__SWIG_7(SwigClassWrapper *farg1, size_t const 
   index_int *arg5 = 0 ;
   bool (*arg6)(void *,void *) = (bool (*)(void *,void *)) 0 ;
   
-  arg1 = (void **)farg1->cptr;
-  arg2 = (size_t)(*farg2);
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
   arg3 = (void *)(*farg3);
   arg4 = (index_int *)(farg4);
   arg5 = (index_int *)(farg5);
@@ -1209,15 +1209,15 @@ SWIGEXPORT void _wrap_minmax_element__SWIG_6(SwigArrayWrapper *farg1, int *farg3
 }
 
 
-SWIGEXPORT void _wrap_minmax_element__SWIG_7(SwigClassWrapper *farg1, size_t const *farg2, int *farg3, int *farg4, bool (*farg5)(void *,void *)) {
+SWIGEXPORT void _wrap_minmax_element__SWIG_7(SwigArrayWrapper *farg1, int *farg3, int *farg4, bool (*farg5)(void *,void *)) {
   void **arg1 = (void **) 0 ;
   size_t arg2 ;
   index_int *arg3 = 0 ;
   index_int *arg4 = 0 ;
   bool (*arg5)(void *,void *) = (bool (*)(void *,void *)) 0 ;
   
-  arg1 = (void **)farg1->cptr;
-  arg2 = (size_t)(*farg2);
+  arg1 = (void **)farg1->data;
+  arg2 = farg1->size;
   arg3 = (index_int *)(farg3);
   arg4 = (index_int *)(farg4);
   arg5 = (bool (*)(void *,void *))(*farg5);


### PR DESCRIPTION
This instantiates std library algorithms on arrays of `void*` using functions with signature `bool(void*, void*)`. Using this, *any* array of any fortran object can be sorted.