### PR TITLE
Improve support for downstream usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,10 @@ function(flibcpp_add_module name)
     )
   endif()
 
+  # Allow the library to be referred to by its namespaced version, for use by
+  # downstream projects that *directly* compile flibcpp
+  add_library(${FLIBCPP_NAMESPACE}${name} ALIAS ${name})
+
   # Compile C++ code with C++11
   target_compile_features(${name}
     PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,14 +137,15 @@ set(FLIBCPP_NAMESPACE Flibcpp::)
 set(FLIBCPP_LIBRARIES)
 
 function(flibcpp_add_module name)
-  set(src_file "${FLIBCPP_INTERFACE_DIR}/${name}.i")
-  # We're using C++
-  set_property(SOURCE "${src_file}" PROPERTY CPLUSPLUS ON)
-  # We need to include the source directory
-  set_property(SOURCE "${src_file}" PROPERTY USE_TARGET_INCLUDE_DIRECTORIES ON)
-
   if (FLIBCPP_USE_SWIG)
     # SWIG is available; actually generate the library dynamically.
+
+    set(src_file "${FLIBCPP_INTERFACE_DIR}/${name}.i")
+    # We're using C++
+    set_property(SOURCE "${src_file}" PROPERTY CPLUSPLUS ON)
+    # We need to include the source directory
+    set_property(SOURCE "${src_file}" PROPERTY USE_TARGET_INCLUDE_DIRECTORIES ON)
+
     # Create the library
     swig_add_library(${name}
       LANGUAGE Fortran

--- a/cmake/FlibcppConfig.cmake.in
+++ b/cmake/FlibcppConfig.cmake.in
@@ -9,3 +9,10 @@ endif()
 
 set(Flibcpp_LIBRARIES @FLIBCPP_LIBRARIES@)
 
+set(Flibcpp_BUILD_SHARED_LIBS @BUILD_SHARED_LIBS@)
+
+if (NOT "@Flibcpp_BUILD_SHARED_LIBS@")
+  # Downstream libraries must find and link to the C++ runtimes themselves since
+  # they can't use the shared library dependencies
+  enable_language(CXX)
+endif()

--- a/src/flc_algorithm.f90
+++ b/src/flc_algorithm.f90
@@ -640,16 +640,17 @@ subroutine SWIGTM_fin_int32_t_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT32_T), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT32_T), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_sort__SWIG_1(data)
 use, intrinsic :: ISO_C_BINDING
@@ -664,16 +665,17 @@ subroutine SWIGTM_fin_int64_t_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT64_T), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT64_T), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_sort__SWIG_2(data)
 use, intrinsic :: ISO_C_BINDING
@@ -688,16 +690,17 @@ subroutine SWIGTM_fin_double_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   real(C_DOUBLE), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   real(C_DOUBLE), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_sort__SWIG_3(data)
 use, intrinsic :: ISO_C_BINDING
@@ -748,16 +751,17 @@ subroutine SWIGTM_fin_void_Sm__Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   type(C_PTR), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   type(C_PTR), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_sort__SWIG_7(data, cmp)
 use, intrinsic :: ISO_C_BINDING
@@ -891,16 +895,17 @@ subroutine SWIGTM_fin_int_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_argsort__SWIG_1(data, idx)
 use, intrinsic :: ISO_C_BINDING

--- a/src/flc_random.f90
+++ b/src/flc_random.f90
@@ -237,16 +237,17 @@ subroutine SWIGTM_fin_int32_t_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT32_T), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT32_T), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_uniform_int_distribution__SWIG_0(left, right, g, data)
 use, intrinsic :: ISO_C_BINDING
@@ -270,16 +271,17 @@ subroutine SWIGTM_fin_int64_t_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT64_T), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT64_T), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine swigf_uniform_int_distribution__SWIG_1(left, right, g, data)
 use, intrinsic :: ISO_C_BINDING
@@ -303,16 +305,17 @@ subroutine SWIGTM_fin_double_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   real(C_DOUBLE), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   real(C_DOUBLE), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 subroutine uniform_real_distribution(left, right, g, data)
 use, intrinsic :: ISO_C_BINDING

--- a/src/flc_string.f90
+++ b/src/flc_string.f90
@@ -405,7 +405,7 @@ subroutine SWIGTM_fin_char_Sm_(finp, iminp, temp)
   i = len(finp) + 1
   temp(i) = C_NULL_CHAR ! C finp compatibility
   iminp%data = c_loc(temp)
-  iminp%size = len(finp)
+  iminp%size = len(finp, kind=C_SIZE_T)
 end subroutine
 
 function swigf_new_string__SWIG_2(s) &

--- a/src/flc_vector.f90
+++ b/src/flc_vector.f90
@@ -1471,16 +1471,17 @@ subroutine SWIGTM_fin_int32_t_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT32_T), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT32_T), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 function swigf_new_VectorInt4__SWIG_4(data) &
 result(self)
@@ -1863,16 +1864,17 @@ subroutine SWIGTM_fin_int64_t_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   integer(C_INT64_T), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   integer(C_INT64_T), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 function swigf_new_VectorInt8__SWIG_4(data) &
 result(self)
@@ -2255,16 +2257,17 @@ subroutine SWIGTM_fin_double_Sb__SB_(finp, iminp)
   use, intrinsic :: ISO_C_BINDING
   real(C_DOUBLE), dimension(:), intent(in), target :: finp
   type(SwigArrayWrapper), intent(out) :: iminp
+  integer(C_SIZE_T) :: sz
   real(C_DOUBLE), pointer :: imtemp
 
-  if (size(finp) > 0) then
+  sz = size(finp, kind=C_SIZE_T)
+  if (sz > 0_c_size_t) then
     imtemp => finp(1)
     iminp%data = c_loc(imtemp)
-    iminp%size = size(finp)
   else
     iminp%data = c_null_ptr
-    iminp%size = 0
   end if
+  iminp%size = sz
 end subroutine
 function swigf_new_VectorReal8__SWIG_4(data) &
 result(self)
@@ -2393,7 +2396,7 @@ subroutine SWIGTM_fin_char_Sm_(finp, iminp, temp)
   i = len(finp) + 1
   temp(i) = C_NULL_CHAR ! C finp compatibility
   iminp%data = c_loc(temp)
-  iminp%size = len(finp)
+  iminp%size = len(finp, kind=C_SIZE_T)
 end subroutine
 
 function swigf_new_VectorString__SWIG_3(count, v) &

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,6 @@
 # Create test with dependencies
 macro(swig_fortran_add_test TESTNAME)
   add_executable(${TESTNAME}.exe ${TESTNAME}.F90)
-  message("Linking ${TESTNAME} against ${ARGN}")
   target_link_libraries(${TESTNAME}.exe ${ARGN})
   add_test(NAME ${TESTNAME} COMMAND ${TESTNAME}.exe)
 endmacro()


### PR DESCRIPTION
- Allow direct `add_subdirectory` inclusion by downstream code
- Fix downstream pure-Fortran builds when compiled as static libraries