### PR TITLE
Tweaks for cmake compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,9 @@ if(CMAKE_VERSION VERSION_LESS 3.18)
 endif()
 
 if(FLIBCPP_USE_SWIG)
-  find_package(SWIG COMPONENTS fortran REQUIRED)
+  if(NOT SWIG_fortran_FOUND)
+    find_package(SWIG COMPONENTS fortran REQUIRED)
+  endif()
 
   if(CMAKE_VERSION VERSION_LESS 3.12)
     message(FATAL_ERROR "CMake 3.12 or higher is required to regenerate the "

--- a/cmake/FlibcppVersion.cmake
+++ b/cmake/FlibcppVersion.cmake
@@ -14,7 +14,7 @@ FlibcppVersion
 
 
   ``<projname>``
-  Name of the project.
+    Name of the project.
 
   This command sets the following variables in the parent package::
 
@@ -55,7 +55,7 @@ function(flibcpp_find_version PROJNAME GIT_VERSION_FILE)
         RESULT_VARIABLE _GIT_RESULT
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )
-      if(NOT _GIT_RESULT EQUAL "0")
+      if(_GIT_RESULT)
         message(WARNING "Failed to get ${PROJNAME} version from git: "
           "${_GIT_ERR}")
       elseif(NOT _VERSION_STRING)


### PR DESCRIPTION
If built by a project that includes SWIG for python or other languages, don't re-find SWIG (which causes verbose/confusing messages and extra work)